### PR TITLE
Add missing records error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ if(NOT LLVM_ENABLE_RTTI)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
 endif()
 
-add_subdirectory(fmt)
+# add_subdirectory(fmt)
 
 add_executable(cppmm cppmm.cpp pystring.cpp)
 target_link_libraries(cppmm clangTooling clangBasic clangASTMatchers fmt)

--- a/cppmm.cpp
+++ b/cppmm.cpp
@@ -1170,6 +1170,16 @@ int main(int argc, const char** argv) {
         std::set<std::string> includes;
 
         for (const auto& rec_pair : bind_file.second.records) {
+            if (records.find(rec_pair.first) == records.end()) {
+                fmt::print("Could not find record {}.\nAvailable records are:\n", rec_pair.first);
+
+                for (const auto& records_pair : records) {
+                    fmt::print("\t{}\n", records_pair.first);
+                }
+
+                return 1;
+            }
+
             const auto& record = records[rec_pair.first];
             if (record.kind == cppmm::TypeKind::OpaquePtr) {
                 declarations +=


### PR DESCRIPTION
There may be cases when the records map is either missing a given record. So, rather than have the bindings generate bad values, just error out.