### PR TITLE
Upgrade to llvm 11

### DIFF
--- a/src/decls.cpp
+++ b/src/decls.cpp
@@ -5,6 +5,7 @@
 
 #include "pystring.h"
 
+#include <clang/AST/ASTContext.h>
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/Type.h>
 
@@ -271,7 +272,7 @@ std::string get_decl_comment(const Decl* decl) {
     const RawComment* rc = ctx.getRawCommentForDeclNoCache(decl);
     std::string result;
     if (rc) {
-        std::string raw = rc->getRawText(sm);
+        std::string raw = rc->getRawText(sm).str();
         // dedent lines
         std::vector<std::string> lines;
         pystring::splitlines(raw, lines);

--- a/src/match_bindings.cpp
+++ b/src/match_bindings.cpp
@@ -54,7 +54,7 @@ void MatchBindingsCallback::handle_enum(const EnumDecl* enum_decl) {
     ASTContext& ctx = enum_decl->getASTContext();
     SourceManager& sm = ctx.getSourceManager();
     const auto& loc = enum_decl->getLocation();
-    std::string filename = sm.getFilename(loc);
+    std::string filename = sm.getFilename(loc).str();
 
     cppmm::ExportedEnum ex_enum;
     ex_enum.cpp_name = enum_decl->getNameAsString();
@@ -116,7 +116,7 @@ void MatchBindingsCallback::handle_record(const CXXRecordDecl* record) {
     ASTContext& ctx = record->getASTContext();
     SourceManager& sm = ctx.getSourceManager();
     const auto& loc = record->getLocation();
-    std::string filename = sm.getFilename(loc);
+    std::string filename = sm.getFilename(loc).str();
     // fmt::print("    {}:{}:{}\n", filename, sm.getSpellingLineNumber(loc),
     //            sm.getSpellingColumnNumber(loc));
 
@@ -143,7 +143,7 @@ void MatchBindingsCallback::handle_function(const FunctionDecl* function) {
     // figure out which file we're in
     ASTContext& ctx = function->getASTContext();
     SourceManager& sm = ctx.getSourceManager();
-    std::string filename = sm.getFilename(function->getBeginLoc());
+    std::string filename = sm.getFilename(function->getBeginLoc()).str();
 
     auto namespaces = get_namespaces(function->getParent());
 
@@ -167,7 +167,7 @@ void MatchBindingsCallback::handle_method(const CXXMethodDecl* method) {
         ASTContext& ctx = method->getASTContext();
         SourceManager& sm = ctx.getSourceManager();
 
-        std::string filename = sm.getFilename(method->getBeginLoc());
+        std::string filename = sm.getFilename(method->getBeginLoc()).str();
 
         auto namespaces = get_namespaces(method->getParent()->getParent());
         ex_classes[class_name] =


### PR DESCRIPTION
This is just because initially I used the version of llvm+clang I had on my system. Which was 11.
Since then I've downloaded 10.0.1.
But seeing as it's a new project, I figure we might as well start out with the latest stable llvm ?