### PR TITLE
Add CMAKE_PREFIX_PATH to readme example of how to build cppmm

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ git submodule update --init
 To build:
 ```
 mkdir build && cd build
-env LLVM_ROOT=</path/to/llvm/installation> cmake ..
+env LLVM_ROOT=</path/to/llvm/installation> CMAKE_PREFIX_PATH=$LLVM_ROOT/lib/cmake cmake ..
 make
 ```
 


### PR DESCRIPTION
I had to add CMAKE_PREFIX_PATH to env when configuring. To pick up cmake modules from llvm.