### PR TITLE
Normalize the file paths given from the command line

### DIFF
--- a/src/cppmm.cpp
+++ b/src/cppmm.cpp
@@ -102,7 +102,8 @@ int main(int argc, const char** argv) {
         // /config.toml
         for (const auto& entry : fs::directory_iterator(src_path[0])) {
             if (entry.path().extension() == ".cpp") {
-                dir_paths.push_back(entry.path().string());
+                dir_paths.push_back(ps::os::path::abspath(entry.path().string(),
+                                    cwd));
             }
         }
     } else {
@@ -110,7 +111,7 @@ int main(int argc, const char** argv) {
         // work with (old behaviour)
         // TODO: can we reliably keep this working?
         for (const auto& s : src_path) {
-            dir_paths.push_back(s);
+            dir_paths.push_back(ps::os::path::abspath(s, cwd));
         }
     }
     ClangTool Tool(OptionsParser.getCompilations(),


### PR DESCRIPTION
I hit this issue straight off the bat.

```
cppmm ./bind ...
```

The bind directory I gave was relative, but the file paths given by clang for records are absolute. So I had duplicate entries in the ex_files map, the last entry was empty so the result was an empty header and cpp file, as there were no declarations or definitions to write.

Took me a while to track down.