### PR TITLE
Added some missing include directives, which are failing my builds

### DIFF
--- a/src/decls.hpp
+++ b/src/decls.hpp
@@ -7,6 +7,7 @@
 #include "record.hpp"
 #include "vector.hpp"
 
+#include <clang/AST/ASTContext.h>
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/Type.h>
 

--- a/src/namespaces.hpp
+++ b/src/namespaces.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include <string>
+#include <unordered_map>
 
 #include <clang/AST/DeclCXX.h>
 


### PR DESCRIPTION
Might be that your third party headers are not the same as mine... which might be why your builds are passing.
I'm on 'clang+llvm-11.0.0', darwin.