### PR TITLE
Asttoc - Added "n" method to ast nodes

### DIFF
--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -141,6 +141,14 @@ struct NodeBuiltinType : public NodeType {
         : NodeType(qualified_name, id, NodeKind::BuiltinType,
                    type_name, const_)
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeBuiltinType;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -155,6 +163,14 @@ struct NodePointerType : public NodeType {
                     NodeTypePtr && pointee_type, bool const_)
         : NodeType(qualified_name, id, NodeKind::PointerType, type_name, const_)
         , pointer_kind(pointer_kind), pointee_type(std::move(pointee_type)) {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodePointerType;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -166,6 +182,14 @@ struct NodeRecordType : public NodeType {
                    std::string type_name, NodeId record, bool const_)
         : NodeType(qualified_name, id, NodeKind::RecordType, type_name, const_),
           record(record) {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeRecordType;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -177,6 +201,14 @@ struct NodeEnumType : public NodeType {
                  std::string type_name, NodeId enm, bool const_) // TODO LT: Hook up const later
         : NodeType(qualified_name, id, NodeKind::EnumType, type_name, const_),
           enm(enm) {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeEnumType;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -192,6 +224,14 @@ struct NodeArrayType : public NodeType {
         : NodeType(qualified_name, id, NodeKind::ArrayType, type_name, const_)
         , size(size)
         , element_type(std::move(element_type)) {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeArrayType;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -254,6 +294,14 @@ struct NodeFunctionCallExpr : public NodeExpr { // TODO LT: Added by luke, like 
         : NodeExpr(kind, name)
         , args(args)
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeFunctionCallExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -267,6 +315,14 @@ struct NodeMethodCallExpr : public NodeFunctionCallExpr { // TODO LT: Added by l
         : NodeFunctionCallExpr(name, args, NodeKind::MethodCallExpr)
         , this_(std::move(this_))
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeMethodCallExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -279,6 +335,14 @@ struct NodeVarRefExpr : public NodeExpr { // TODO LT: Added by luke, like clang 
         : NodeExpr(NodeKind::VarRefExpr)
         , var_name(var_name)
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeVarRefExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -291,6 +355,14 @@ struct NodeRefExpr : public NodeExpr { // TODO LT: Added by luke = &()
         : NodeExpr(NodeKind::RefExpr)
         , inner(std::move(inner))
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeRefExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -303,6 +375,14 @@ struct NodeDerefExpr : public NodeExpr { // TODO LT: Added by luke = *()
         : NodeExpr(NodeKind::DerefExpr)
         , inner(std::move(inner))
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeDerefExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -315,6 +395,14 @@ struct NodeReturnExpr : public NodeExpr { // TODO LT: Added by luke = *()
         : NodeExpr(NodeKind::ReturnExpr)
         , inner(std::move(inner))
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeReturnExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -332,6 +420,14 @@ struct NodeCastExpr : public NodeExpr { // TODO LT: Added by luke
         , type(std::move(type))
         , cast_kind(cast_kind)
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeCastExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -346,6 +442,14 @@ struct NodePlacementNewExpr : public NodeExpr { // TODO LT: Added by luke new ()
         , address(std::move(address))
         , constructor(std::move(constructor))
     {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodePlacementNewExpr;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -366,6 +470,14 @@ struct NodeFunction : public NodeAttributeHolder {
                               attrs),
           short_name(short_name), return_type(std::move(return_type)),
           params(std::move(params)) {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeFunction;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -387,6 +499,14 @@ struct NodeMethod : public NodeFunction {
     {
         kind = NodeKind::Method;
     }
+
+    // A static method for creating this as a shared pointer
+    using This = NodeMethod;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -415,6 +535,14 @@ struct NodeRecord : public NodeAttributeHolder {
                uint32_t size, uint32_t align)
         : NodeAttributeHolder(qualified_name, id, NodeKind::Record, attrs),
           tu(tu), size(size), align(align), force_alignment(false) {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeRecord;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------
@@ -434,6 +562,13 @@ struct NodeEnum : public NodeAttributeHolder {
         : NodeAttributeHolder(qualified_name, id, NodeKind::Enum, attrs),
           variants(variants), size(size), align(align) {
     }
+
+    using This = NodeEnum;
+	template<typename ... Args>
+	static std::shared_ptr<This> n(Args&& ... args)
+	{
+		return std::make_shared<This>(std::forward<Args>(args)...);
+	}
 };
 
 //------------------------------------------------------------------------------

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -144,11 +144,11 @@ struct NodeBuiltinType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeBuiltinType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -166,11 +166,11 @@ struct NodePointerType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodePointerType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -185,11 +185,11 @@ struct NodeRecordType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeRecordType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -204,11 +204,11 @@ struct NodeEnumType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeEnumType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -227,11 +227,11 @@ struct NodeArrayType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeArrayType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -297,11 +297,11 @@ struct NodeFunctionCallExpr : public NodeExpr { // TODO LT: Added by luke, like 
 
     // A static method for creating this as a shared pointer
     using This = NodeFunctionCallExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -318,11 +318,11 @@ struct NodeMethodCallExpr : public NodeFunctionCallExpr { // TODO LT: Added by l
 
     // A static method for creating this as a shared pointer
     using This = NodeMethodCallExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -338,11 +338,11 @@ struct NodeVarRefExpr : public NodeExpr { // TODO LT: Added by luke, like clang 
 
     // A static method for creating this as a shared pointer
     using This = NodeVarRefExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -358,11 +358,11 @@ struct NodeRefExpr : public NodeExpr { // TODO LT: Added by luke = &()
 
     // A static method for creating this as a shared pointer
     using This = NodeRefExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -378,11 +378,11 @@ struct NodeDerefExpr : public NodeExpr { // TODO LT: Added by luke = *()
 
     // A static method for creating this as a shared pointer
     using This = NodeDerefExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -398,11 +398,11 @@ struct NodeReturnExpr : public NodeExpr { // TODO LT: Added by luke = *()
 
     // A static method for creating this as a shared pointer
     using This = NodeReturnExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -423,11 +423,11 @@ struct NodeCastExpr : public NodeExpr { // TODO LT: Added by luke
 
     // A static method for creating this as a shared pointer
     using This = NodeCastExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -445,11 +445,11 @@ struct NodePlacementNewExpr : public NodeExpr { // TODO LT: Added by luke new ()
 
     // A static method for creating this as a shared pointer
     using This = NodePlacementNewExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -473,11 +473,11 @@ struct NodeFunction : public NodeAttributeHolder {
 
     // A static method for creating this as a shared pointer
     using This = NodeFunction;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -502,11 +502,11 @@ struct NodeMethod : public NodeFunction {
 
     // A static method for creating this as a shared pointer
     using This = NodeMethod;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -538,11 +538,11 @@ struct NodeRecord : public NodeAttributeHolder {
 
     // A static method for creating this as a shared pointer
     using This = NodeRecord;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -564,11 +564,11 @@ struct NodeEnum : public NodeAttributeHolder {
     }
 
     using This = NodeEnum;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -120,8 +120,7 @@ NodeTypePtr convert_builtin_type(TranslationUnit & c_tu,
     // TODO LT: Do mapping of c++ builtins to c builtins
 
     // For now just copy everything one to one.
-    return std::make_shared<NodeBuiltinType>(t->name, 0, t->type_name,
-                                             t->const_);
+    return NodeBuiltinType::n(t->name, 0, t->type_name, t->const_);
 }
 
 
@@ -166,8 +165,8 @@ NodeTypePtr convert_record_type(TranslationUnit & c_tu,
     add_declaration(c_tu, node_ptr, in_reference);
 
     const auto & record = *static_cast<const NodeRecord*>(node_ptr.get());
-    return std::make_shared<NodeRecordType>(t->name, 0, record.name,
-                                            record.id, t->const_);
+
+    return NodeRecordType::n(t->name, 0, record.name, record.id, t->const_);
 }
 
 //------------------------------------------------------------------------------
@@ -187,10 +186,10 @@ NodeTypePtr convert_pointer_type(TranslationUnit & c_tu,
     }
 
     // For now just copy everything one to one.
-    return std::make_shared<NodePointerType>(p->name, 0, p->type_name,
-                                             PointerKind::Pointer,
-                                             std::move(pointee_type),
-                                             p->const_);
+    return NodePointerType::n(p->name, 0, p->type_name,
+                              PointerKind::Pointer,
+                              std::move(pointee_type),
+                              p->const_);
 }
 
 //------------------------------------------------------------------------------
@@ -254,19 +253,19 @@ void opaquebytes_record(NodeRecord & c_record)
 Param self_param(const NodeRecord & c_record, bool const_)
 {
 
-    auto record = std::make_shared<NodeRecordType>(
-                                                "",
-                                                0,
-                                                c_record.name,
-                                                c_record.id,
-                                                const_
-                                           );
+    auto record = NodeRecordType::n(
+                                    "",
+                                    0,
+                                    c_record.name,
+                                    c_record.id,
+                                    const_
+    );
 
-    auto pointer = std::make_shared<NodePointerType>("", 0,
-                                           "",
-                                           PointerKind::Pointer,
-                                           std::move(record), false // TODO LT: Maybe references should be const pointers
-                                           );
+    auto pointer = NodePointerType::n("", 0,
+                                      "",
+                                      PointerKind::Pointer,
+                                      std::move(record), false // TODO LT: Maybe references should be const pointers
+                                      );
 
     return Param("self", std::move(pointer), 0);
 }
@@ -274,17 +273,17 @@ Param self_param(const NodeRecord & c_record, bool const_)
 //------------------------------------------------------------------------------
 NodeExprPtr this_reference(const NodeRecord & cpp_record, bool const_)
 {
-    auto record = std::make_shared<NodeRecordType>(
+    auto record = NodeRecordType::n(
                     "", 0, cpp_record.name, cpp_record.id, const_
     );
-    auto type = std::make_shared<NodePointerType>(
+    auto type = NodePointerType::n(
                     "", 0, "", PointerKind::Pointer,
                     std::move(record), false 
     );
-    auto self = std::make_shared<NodeVarRefExpr>("self");
-    auto cast = std::make_shared<NodeCastExpr>(std::move(self),
-                                               std::move(type),
-                                               "reinterpret");
+    auto self = NodeVarRefExpr::n("self");
+    auto cast = NodeCastExpr::n(std::move(self),
+                                std::move(type),
+                                "reinterpret");
 
     return cast;
 }
@@ -307,14 +306,8 @@ bool should_wrap(const NodeMethod & cpp_method)
 //------------------------------------------------------------------------------
 NodeExprPtr convert_builtin_to(const NodeTypePtr & t, const NodeExprPtr & name)
 {
-#if 0
-    auto type = NodeTypePtr(t);
-    return std::make_shared<NodeCastExpr>(NodeExprPtr(name),
-                                          std::move(type),
-                                          "static");
-#else
+    // TODO LT: Will make this smarter
     return NodeExprPtr(name);
-#endif
 }
 
 //------------------------------------------------------------------------------
@@ -323,16 +316,16 @@ NodeExprPtr convert_record_to(const NodeTypePtr & t, const NodeExprPtr & name)
     // TODO LT: Assuming opaquebytes at the moment, opaqueptr will have a
     // different implementation.
     //
-    auto reference = std::make_shared<NodeRefExpr>(NodeExprPtr(name));
+    auto reference = NodeRefExpr::n(NodeExprPtr(name));
     auto type =\
-        std::make_shared<NodePointerType>(
+        NodePointerType::n(
             "", 0, "", PointerKind::Pointer,
             std::move(NodeTypePtr(t)),
             false
     );
-    auto inner = std::make_shared<NodeCastExpr>(
+    auto inner = NodeCastExpr::n(
         std::move(reference), std::move(type), "reinterpret");
-    return std::make_shared<NodeDerefExpr>(std::move(inner));
+    return NodeDerefExpr::n(std::move(inner));
 
     /*
     // Above code could look like this later.
@@ -358,23 +351,23 @@ NodeExprPtr convert_pointer_to(const NodeTypePtr & t, const NodeExprPtr & name)
         case PointerKind::Pointer:
             {
                 auto type = NodeTypePtr(t);
-                return std::make_shared<NodeCastExpr>(NodeExprPtr(name),
-                                                      std::move(type),
-                                                      "reinterpret");
+                return NodeCastExpr::n(NodeExprPtr(name),
+                                       std::move(type),
+                                       "reinterpret");
             }
         case PointerKind::RValueReference: // TODO LT: Add support for rvalue reference
         case PointerKind::Reference:
             {
                 auto pointee = NodeTypePtr(p->pointee_type);
                 auto type =\
-                    std::make_shared<NodePointerType>(
+                    NodePointerType::n(
                         "", 0, "", PointerKind::Pointer,
                         std::move(pointee),
                         p->const_
                 );
-                auto inner = std::make_shared<NodeCastExpr>(
+                auto inner = NodeCastExpr::n(
                     NodeExprPtr(name), std::move(type), "reinterpret");
-                return std::make_shared<NodeDerefExpr>(std::move(inner));
+                return NodeDerefExpr::n(std::move(inner));
             }
         default:
             break;
@@ -417,10 +410,10 @@ NodeExprPtr convert_record_from(
                                  const NodeTypePtr & to_ptr,
                                  const NodeExprPtr & name)
 {
-    auto reference = std::make_shared<NodeRefExpr>(NodeExprPtr(name));
-    auto inner = std::make_shared<NodeCastExpr>(
+    auto reference = NodeRefExpr::n(NodeExprPtr(name));
+    auto inner = NodeCastExpr::n(
         std::move(reference), NodeTypePtr(to_ptr), "reinterpret");
-    return std::make_shared<NodeDerefExpr>(std::move(inner));
+    return NodeDerefExpr::n(std::move(inner));
 }
 
 //------------------------------------------------------------------------------
@@ -438,15 +431,15 @@ NodeExprPtr convert_pointer_from(
     {
         case PointerKind::Pointer:
             {
-                return std::make_shared<NodeCastExpr>(NodeExprPtr(name),
+                return NodeCastExpr::n(NodeExprPtr(name),
                                                       NodeTypePtr(to_ptr),
                                                       "reinterpret");
             }
         case PointerKind::RValueReference: // TODO LT: Add support for rvalue reference
         case PointerKind::Reference:
             {
-                auto ref = std::make_shared<NodeRefExpr>(NodeExprPtr(name));
-                return std::make_shared<NodeCastExpr>(
+                auto ref = NodeRefExpr::n(NodeExprPtr(name));
+                return NodeCastExpr::n(
                     NodeExprPtr(name), NodeTypePtr(to_ptr), "reinterpret");
             }
         default:
@@ -481,7 +474,7 @@ void argument(std::vector<NodeExprPtr> & args, const Param & param)
 {
     auto argument =
         convert_to(param.type,
-                   std::make_shared<NodeVarRefExpr>(param.name));
+                   NodeVarRefExpr::n(param.name));
     args.push_back(argument);
 }
 
@@ -500,11 +493,9 @@ NodeExprPtr opaquebytes_constructor_body(RecordRegistry & record_registry,
     }
 
     // Create the method call expression
-    return std::make_shared<NodePlacementNewExpr>(
-        std::make_shared<NodeVarRefExpr>("self"),
-        std::make_shared<NodeFunctionCallExpr>(cpp_method.short_name,
-                                               args
-        )
+    return NodePlacementNewExpr::n(
+        NodeVarRefExpr::n("self"),
+        NodeFunctionCallExpr::n(cpp_method.short_name, args)
     );
 }
 
@@ -528,9 +519,9 @@ NodeExprPtr opaquebytes_method_body(RecordRegistry & record_registry,
 
     // Create the method call expression
     auto method_call =
-        std::make_shared<NodeMethodCallExpr>(std::move(this_),
-                                             cpp_method.short_name,
-                                             args
+        NodeMethodCallExpr::n(std::move(this_),
+                              cpp_method.short_name,
+                              args
     );
 
     // Convert the result
@@ -544,7 +535,7 @@ NodeExprPtr opaquebytes_method_body(RecordRegistry & record_registry,
     }
     else
     {
-        return std::make_shared<NodeReturnExpr>(
+        return NodeReturnExpr::n(
             convert_from(cpp_method.return_type, c_return, method_call));
     }
     //return method_call;
@@ -610,7 +601,7 @@ void opaquebytes_method(RecordRegistry & record_registry,
                                     c_return, cpp_method);
 
     // Add the new function to the translation unit
-    auto c_function = std::make_shared<NodeFunction>(
+    auto c_function = NodeFunction::n(
                         compute_c_name(cpp_method.name), PLACEHOLDER_ID,
                         cpp_method.attrs, "", std::move(c_return),
                         std::move(c_params));
@@ -642,8 +633,7 @@ void record_entry(NodeId & record_id,
     const auto c_record_name = compute_c_name(cpp_record.name);
 
     // Create the c record
-    auto c_record =\
-        std::make_shared<NodeRecord>(
+    auto c_record = NodeRecord::n(
                    c_tu,
                    c_record_name, record_id++, cpp_record.attrs,
                    cpp_record.size, cpp_record.align);

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -56,7 +56,7 @@ NodeTypePtr read_type(const nln::json & json);
 
 //------------------------------------------------------------------------------
 NodeTypePtr read_type_builtin(const nln::json & json) {
-    return std::make_shared<NodeBuiltinType>(
+    return NodeBuiltinType::n(
             "",
             json[ID].get<Id>(),
             json[TYPE].get<std::string>(),
@@ -67,7 +67,7 @@ NodeTypePtr read_type_builtin(const nln::json & json) {
 //------------------------------------------------------------------------------
 NodeTypePtr read_type_pointer(const nln::json & json,
                               PointerKind pointer_kind) {
-    return std::make_shared<NodePointerType>(
+    return NodePointerType::n(
             "",
             json[ID].get<Id>(),
             json[TYPE].get<std::string>(),
@@ -79,7 +79,7 @@ NodeTypePtr read_type_pointer(const nln::json & json,
 
 //------------------------------------------------------------------------------
 NodeTypePtr read_type_record(const nln::json & json) {
-    return std::make_shared<NodeRecordType>(
+    return NodeRecordType::n(
             "",
             json[ID].get<Id>(),
             json[TYPE].get<std::string>(),
@@ -90,7 +90,7 @@ NodeTypePtr read_type_record(const nln::json & json) {
 
 //------------------------------------------------------------------------------
 NodeTypePtr read_type_enum(const nln::json & json) {
-    return std::make_shared<NodeEnumType>(
+    return NodeEnumType::n(
             "",
             json[ID].get<Id>(),
             json[TYPE].get<std::string>(),
@@ -149,7 +149,7 @@ NodePtr read_function(const TranslationUnit::Ptr & tu, const nln::json & json) {
         params.push_back(read_param(i));
     }
 
-    return std::make_shared<NodeFunction>(
+    return NodeFunction::n(
                       qualified_name, id, _attrs, short_name,
                       std::move(return_type),
                       std::move(params));
@@ -209,7 +209,7 @@ NodePtr read_record(const TranslationUnit::Ptr & tu, const nln::json & json) {
 
     // Instantiate the translation unit
     auto result =\
-        std::make_shared<NodeRecord>(tu, name, id, _attrs, size, align);
+        NodeRecord::n(tu, name, id, _attrs, size, align);
 
     // Pull out the methods
     for (const auto & i : json[METHODS] ){
@@ -248,8 +248,8 @@ NodePtr read_enum(const TranslationUnit::Ptr & tu, const nln::json & json) {
     }
 
     // Instantiate the translation unit
-    auto result =\
-        std::make_shared<NodeEnum>(tu, name, id, _attrs, variants, size, align);
+    auto result =
+        NodeEnum::n(tu, name, id, _attrs, variants, size, align);
 
     // Return the result
     return result;

--- a/asttoc/src/main.cpp
+++ b/asttoc/src/main.cpp
@@ -28,7 +28,7 @@ int main()
 {
     generate("../test/imath/ref", "out");
     generate("../test/std/ref", "out");
-    generate("../test/oiio/ref", "out");
+    //generate("../test/oiio/ref", "out");
 
     return 0;
 }


### PR DESCRIPTION
This is just to make it easier to read the code in cppmm_ast_add_c.cpp and cppmm_ast_read.cpp.
I've moved all the make_shared calls to a static method "n" for "new" on each node object. This just does a perfect forward of the constructor parameters but returns a shared_ptr.