### PR TITLE
Draft: Asttoc to casts

### DIFF
--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -23,6 +23,7 @@ enum class NodeKind : uint32_t {
     Namespace,
     ArrayType,
     BuiltinType,
+    ConstType,
     PointerType,
     RecordType,
     EnumType,
@@ -484,18 +485,19 @@ struct NodeFunction : public NodeAttributeHolder {
 // NodeMethod
 //------------------------------------------------------------------------------
 struct NodeMethod : public NodeFunction {
-    bool is_static = false;
-    bool is_constructor = false;
-    // TODO LT: Missing const here
+    bool is_static;
+    bool is_constructor;
+    bool is_const;
 
     NodeMethod(std::string qualified_name, NodeId id,
                std::vector<std::string> attrs, std::string short_name,
                NodeTypePtr && return_type, std::vector<Param> && params,
-               bool is_static, bool is_constructor)
+               bool is_static, bool is_constructor, bool is_const)
         : NodeFunction(qualified_name, id, attrs, short_name,
                        std::move(return_type), std::move(params))
           , is_static(is_static)
           , is_constructor(is_constructor)
+          , is_const(is_const)
     {
         kind = NodeKind::Method;
     }

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -159,10 +159,9 @@ struct NodeBuiltinType : public NodeType {
 struct NodePointerType : public NodeType {
     NodeTypePtr pointee_type;
     PointerKind pointer_kind;
-    NodePointerType(std::string qualified_name, NodeId id,
-                    std::string type_name, PointerKind pointer_kind,
+    NodePointerType(PointerKind pointer_kind,
                     NodeTypePtr && pointee_type, bool const_)
-        : NodeType(qualified_name, id, NodeKind::PointerType, type_name, const_)
+        : NodeType("", 0, NodeKind::PointerType, "", const_)
         , pointer_kind(pointer_kind), pointee_type(std::move(pointee_type)) {}
 
     // A static method for creating this as a shared pointer

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -144,11 +144,11 @@ struct NodeBuiltinType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeBuiltinType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -166,11 +166,11 @@ struct NodePointerType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodePointerType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -185,11 +185,11 @@ struct NodeRecordType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeRecordType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -204,11 +204,11 @@ struct NodeEnumType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeEnumType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -227,11 +227,11 @@ struct NodeArrayType : public NodeType {
 
     // A static method for creating this as a shared pointer
     using This = NodeArrayType;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -297,11 +297,11 @@ struct NodeFunctionCallExpr : public NodeExpr { // TODO LT: Added by luke, like 
 
     // A static method for creating this as a shared pointer
     using This = NodeFunctionCallExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -318,11 +318,11 @@ struct NodeMethodCallExpr : public NodeFunctionCallExpr { // TODO LT: Added by l
 
     // A static method for creating this as a shared pointer
     using This = NodeMethodCallExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -338,11 +338,11 @@ struct NodeVarRefExpr : public NodeExpr { // TODO LT: Added by luke, like clang 
 
     // A static method for creating this as a shared pointer
     using This = NodeVarRefExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -358,11 +358,11 @@ struct NodeRefExpr : public NodeExpr { // TODO LT: Added by luke = &()
 
     // A static method for creating this as a shared pointer
     using This = NodeRefExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -378,11 +378,11 @@ struct NodeDerefExpr : public NodeExpr { // TODO LT: Added by luke = *()
 
     // A static method for creating this as a shared pointer
     using This = NodeDerefExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -398,11 +398,11 @@ struct NodeReturnExpr : public NodeExpr { // TODO LT: Added by luke = *()
 
     // A static method for creating this as a shared pointer
     using This = NodeReturnExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -423,11 +423,11 @@ struct NodeCastExpr : public NodeExpr { // TODO LT: Added by luke
 
     // A static method for creating this as a shared pointer
     using This = NodeCastExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -445,11 +445,11 @@ struct NodePlacementNewExpr : public NodeExpr { // TODO LT: Added by luke new ()
 
     // A static method for creating this as a shared pointer
     using This = NodePlacementNewExpr;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -473,11 +473,11 @@ struct NodeFunction : public NodeAttributeHolder {
 
     // A static method for creating this as a shared pointer
     using This = NodeFunction;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -502,11 +502,11 @@ struct NodeMethod : public NodeFunction {
 
     // A static method for creating this as a shared pointer
     using This = NodeMethod;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -538,11 +538,11 @@ struct NodeRecord : public NodeAttributeHolder {
 
     // A static method for creating this as a shared pointer
     using This = NodeRecord;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------
@@ -564,11 +564,11 @@ struct NodeEnum : public NodeAttributeHolder {
     }
 
     using This = NodeEnum;
-	template<typename ... Args>
-	static std::shared_ptr<This> n(Args&& ... args)
-	{
-		return std::make_shared<This>(std::forward<Args>(args)...);
-	}
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
 };
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -508,7 +508,7 @@ NodeExprPtr opaquebytes_method_body(RecordRegistry & record_registry,
                                     const NodeMethod & cpp_method)
 {
     // Create the reference to this
-    auto this_ = this_reference(cpp_record, false); // TODO LT: Missing cpp_method.const_
+    auto this_ = this_reference(cpp_record, cpp_method.is_const);
 
     // Loop over the parameters, creating arguments for the method call
     auto args = std::vector<NodeExprPtr>();

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -577,7 +577,7 @@ void opaquebytes_method(RecordRegistry & record_registry,
 
     // Convert params
     auto c_params = std::vector<Param>();
-    c_params.push_back(self_param(c_record, false)); // TODO LT: Const needs to be passed in here
+    c_params.push_back(self_param(c_record, cpp_method.is_const));
     for(const auto & p : cpp_method.params)
     {
         if(!parameter(c_tu, record_registry, c_params, p))

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -186,8 +186,7 @@ NodeTypePtr convert_pointer_type(TranslationUnit & c_tu,
     }
 
     // For now just copy everything one to one.
-    return NodePointerType::n(p->name, 0, p->type_name,
-                              PointerKind::Pointer,
+    return NodePointerType::n(PointerKind::Pointer,
                               std::move(pointee_type),
                               p->const_);
 }
@@ -261,9 +260,7 @@ Param self_param(const NodeRecord & c_record, bool const_)
                                     const_
     );
 
-    auto pointer = NodePointerType::n("", 0,
-                                      "",
-                                      PointerKind::Pointer,
+    auto pointer = NodePointerType::n(PointerKind::Pointer,
                                       std::move(record), false // TODO LT: Maybe references should be const pointers
                                       );
 
@@ -277,7 +274,7 @@ NodeExprPtr this_reference(const NodeRecord & cpp_record, bool const_)
                     "", 0, cpp_record.name, cpp_record.id, const_
     );
     auto type = NodePointerType::n(
-                    "", 0, "", PointerKind::Pointer,
+                    PointerKind::Pointer,
                     std::move(record), false 
     );
     auto self = NodeVarRefExpr::n("self");
@@ -319,7 +316,7 @@ NodeExprPtr convert_record_to(const NodeTypePtr & t, const NodeExprPtr & name)
     auto reference = NodeRefExpr::n(NodeExprPtr(name));
     auto type =\
         NodePointerType::n(
-            "", 0, "", PointerKind::Pointer,
+            PointerKind::Pointer,
             std::move(NodeTypePtr(t)),
             false
     );
@@ -361,7 +358,7 @@ NodeExprPtr convert_pointer_to(const NodeTypePtr & t, const NodeExprPtr & name)
                 auto pointee = NodeTypePtr(p->pointee_type);
                 auto type =\
                     NodePointerType::n(
-                        "", 0, "", PointerKind::Pointer,
+                        PointerKind::Pointer,
                         std::move(pointee),
                         p->const_
                 );
@@ -412,7 +409,11 @@ NodeExprPtr convert_record_from(
 {
     auto reference = NodeRefExpr::n(NodeExprPtr(name));
     auto inner = NodeCastExpr::n(
-        std::move(reference), NodeTypePtr(to_ptr), "reinterpret");
+        std::move(reference), NodePointerType::n(PointerKind::Pointer,
+                                                 NodeTypePtr(to_ptr),
+                                                 false),
+        "reinterpret"
+    );
     return NodeDerefExpr::n(std::move(inner));
 }
 

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -68,9 +68,6 @@ NodeTypePtr read_type_builtin(const nln::json & json) {
 NodeTypePtr read_type_pointer(const nln::json & json,
                               PointerKind pointer_kind) {
     return NodePointerType::n(
-            "",
-            json[ID].get<Id>(),
-            json[TYPE].get<std::string>(),
             pointer_kind,
             read_type(json[POINTEE]),
             json[CONST].get<bool>()

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -177,6 +177,7 @@ NodeMethod read_method(const nln::json & json) {
     auto static_ = json[STATIC].get<bool>();
     auto constructor = json[CONSTRUCTOR].get<bool>();
     auto return_type = read_type(json[RETURN]);
+    auto const_ = json[CONST].get<bool>();
 
     auto params = std::vector<Param>();
     for(const auto & i: json[PARAMS]) {
@@ -185,7 +186,7 @@ NodeMethod read_method(const nln::json & json) {
 
     return NodeMethod(qualified_name, id, attrs, short_name,
                       std::move(return_type),
-                      std::move(params), static_, constructor);
+                      std::move(params), static_, constructor, const_);
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -53,7 +53,8 @@ std::string convert_builtin_param(const NodeTypePtr & t,
 std::string convert_record_param(const NodeTypePtr & t,
                                  const std::string & name)
 {
-    return fmt::format("{} {}", t->type_name, name);
+    const char * const_ = t->const_ ? " const " : " ";
+    return fmt::format("{}{}{}", t->type_name, const_, name);
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/main.cpp
+++ b/asttoc/src/main.cpp
@@ -27,7 +27,7 @@ void generate(const char * input, const char * output)
 int main()
 {
     generate("../test/imath/ref", "out");
-    generate("../test/std/ref", "out");
+    //generate("../test/std/ref", "out");
     //generate("../test/oiio/ref", "out");
 
     return 0;

--- a/test/imath/bind/imath_vec.cpp
+++ b/test/imath/bind/imath_vec.cpp
@@ -11,8 +11,8 @@ template <class T> class Vec3 {
 public:
     // This allows us to see through to the type in Imath
     using BoundType = ::Imath::Vec3<T>;
+#if 0
 
-    /*
     // we're not actually paying any attention to the method declarations yet
     // no matching
     bool equalWithAbsError(const Vec3<T>& v, T e) const;
@@ -20,18 +20,23 @@ public:
 
     T dot(const ::Imath::Vec3<T>& v) const;
     ::Imath::Vec3<T> cross(const ::Imath::Vec3<T>& v) const;
+    const ::Imath::Vec3<T>& operator+=(const ::Imath::Vec3<T>& v) CPPMM_RENAME(op_iadd) ;
+#endif
 
-    const ::Imath::Vec3<T>& operator+=(const ::Imath::Vec3<T>& v);
+    const ::Imath::Vec3<T>&	normalize ();
+    ::Imath::Vec3<T>     	normalized () const;
+
+#if 0
     ::Imath::Vec3<T> operator+(const ::Imath::Vec3<T>& v) const;
 
     const ::Imath::Vec3<T>& operator-=(const ::Imath::Vec3<T>& v);
     ::Imath::Vec3<T> operator-(const ::Imath::Vec3<T>& v) const
-    CPPMM_RENAME(op_neg);
+    CPPMM_RENAME(op_sub);
 
-    constexpr ::Imath::Vec3<T> operator-() const;// CPPMM_RENAME(op_neg);
+    constexpr ::Imath::Vec3<T> operator-() const CPPMM_RENAME(op_neg);
 
-    const ::Imath::Vec3<T>& operator*=(const ::Imath::Vec3<T>& v);
-    const ::Imath::Vec3<T>& operator*=(T a) CPPMM_RENAME(mul_assign_t);
+    const ::Imath::Vec3<T>& operator*=(const ::Imath::Vec3<T>& v) CPPMM_RENAME(op_neg);
+    const ::Imath::Vec3<T>& operator*=(T a) CPPMM_RENAME(mul_assign_t) CPPMM_RENAME(op_neg);
     ::Imath::Vec3<T> operator*(const ::Imath::Vec3<T>& v) const;
     ::Imath::Vec3<T> operator*(T a) const CPPMM_RENAME(mul_t);
 
@@ -45,7 +50,6 @@ public:
 
     const ::Imath::Vec3<T>& normalize();    // modifies *this
     ::Imath::Vec3<T> normalized() const; // does not modify *this
-    */
 
     // constexpr static unsigned int dimensions();
 
@@ -57,24 +61,29 @@ public:
     // ugh - in order for the explicit instantiation to work we must provide
     // a function body here.
     template <class S> void setValue(S a, S b, S c);
+#endif
 
 } CPPMM_VALUETYPE;
 
 // explicit instantiation
 template class Vec3<float>;
-template class Vec3<int>;
+//template class Vec3<int>;
 using V3f = Imath::V3f;
-using V3i = Imath::V3i;
+//using V3i = Imath::V3i;
 
+#if 0
 // note the 'extern' here otherwise we get an error because we're not
 // defining the template body up above
 extern template void Vec3<float>::setValue(float a, float b, float c);
 extern template void Vec3<int>::setValue(int a, int b, int c);
+#endif
 
 } // namespace cppmm_bind
 
 template class Imath::Vec3<float>;
-template class Imath::Vec3<int>;
+//template class Imath::Vec3<int>;
 
+#if 0
 extern template void Imath::Vec3<float>::setValue(float a, float b, float c);
 extern template void Imath::Vec3<int>::setValue(int a, int b, int c);
+#endif

--- a/test/imath/ref/imath_box.json
+++ b/test/imath/ref/imath_box.json
@@ -1,21 +1,24 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_box.cpp",
+    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_box.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathBox.h>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "/home/anders/packages/openexr/2.4.0/include"
+        "../test/",
+        "../test/imath/bind",
+        "/Volumes/src/packages/usr/local/include",
+        "/Volumes/src/cppmm/build/../test/imath/bind"
     ],
     "id": 5,
     "decls": [
         {
             "kind": "Record",
-            "name": "Imath_2_4::Box<Imath::Vec3<float> >",
+            "name": "Imath_2_5::Box<Imath::Vec3<float> >",
             "short_name": "Box",
             "namespaces": [
-                "Imath_2_4"
+                "Imath_2_5"
             ],
             "id": 6,
             "size": 192,
@@ -31,8 +34,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 1,
-                        "type": "Imath_2_4::Vec3<float>",
-                        "record": 24,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 23,
                         "const": false
                     }
                 },
@@ -42,8 +45,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 1,
-                        "type": "Imath_2_4::Vec3<float>",
-                        "record": 24,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 23,
                         "const": false
                     }
                 }
@@ -53,7 +56,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_4::Box<Imath_2_4::Vec3<float> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -82,12 +85,12 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 2,
-                                "type": "const class Imath_2_4::Vec3<float> &",
+                                "type": "const class Imath_2_5::Vec3<float> &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 1,
-                                    "type": "Imath_2_4::Vec3<float>",
-                                    "record": 24,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 23,
                                     "const": true
                                 },
                                 "const": false
@@ -100,7 +103,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_4::Box<Imath_2_4::Vec3<float> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -129,11 +132,11 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 4,
-                                "type": "const class Imath_2_4::Box<Imath::Vec3<float> > &",
+                                "type": "const class Imath_2_5::Box<Imath::Vec3<float> > &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 3,
-                                    "type": "Imath_2_4::Box<Imath::Vec3<float> >",
+                                    "type": "Imath_2_5::Box<Imath::Vec3<float> >",
                                     "record": 6,
                                     "const": true
                                 },
@@ -147,10 +150,10 @@
         },
         {
             "kind": "Record",
-            "name": "Imath_2_4::Box<Imath::Vec3<int> >",
+            "name": "Imath_2_5::Box<Imath::Vec3<int> >",
             "short_name": "Box",
             "namespaces": [
-                "Imath_2_4"
+                "Imath_2_5"
             ],
             "id": 17,
             "size": 192,
@@ -166,8 +169,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 13,
-                        "type": "Imath_2_4::Vec3<int>",
-                        "record": 31,
+                        "type": "Imath_2_5::Vec3<int>",
+                        "record": -1,
                         "const": false
                     }
                 },
@@ -177,8 +180,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 13,
-                        "type": "Imath_2_4::Vec3<int>",
-                        "record": 31,
+                        "type": "Imath_2_5::Vec3<int>",
+                        "record": -1,
                         "const": false
                     }
                 }
@@ -188,7 +191,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_4::Box<Imath_2_4::Vec3<int> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -217,12 +220,12 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 14,
-                                "type": "const class Imath_2_4::Vec3<int> &",
+                                "type": "const class Imath_2_5::Vec3<int> &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 13,
-                                    "type": "Imath_2_4::Vec3<int>",
-                                    "record": 31,
+                                    "type": "Imath_2_5::Vec3<int>",
+                                    "record": -1,
                                     "const": true
                                 },
                                 "const": false
@@ -235,7 +238,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_4::Box<Imath_2_4::Vec3<int> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -264,11 +267,11 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 16,
-                                "type": "const class Imath_2_4::Box<Imath::Vec3<int> > &",
+                                "type": "const class Imath_2_5::Box<Imath::Vec3<int> > &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 15,
-                                    "type": "Imath_2_4::Box<Imath::Vec3<int> >",
+                                    "type": "Imath_2_5::Box<Imath::Vec3<int> >",
                                     "record": 17,
                                     "const": true
                                 },

--- a/test/imath/ref/imath_vec.json
+++ b/test/imath/ref/imath_vec.json
@@ -1,24 +1,27 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_vec.cpp",
+    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_vec.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathVec.h>",
         "#include <vector>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "/home/anders/packages/openexr/2.4.0/include"
+        "../test/",
+        "../test/imath/bind",
+        "/Volumes/src/packages/usr/local/include",
+        "/Volumes/src/cppmm/build/../test/imath/bind"
     ],
-    "id": 23,
+    "id": 22,
     "decls": [
         {
             "kind": "Record",
-            "name": "Imath_2_4::Vec3<float>",
+            "name": "Imath_2_5::Vec3<float>",
             "short_name": "Vec3",
             "namespaces": [
-                "Imath_2_4"
+                "Imath_2_5"
             ],
-            "id": 24,
+            "id": 23,
             "size": 96,
             "align": 32,
             "alias": "V3f",
@@ -31,7 +34,7 @@
                     "name": "x",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 22,
+                        "id": 24,
                         "type": "float",
                         "const": false
                     }
@@ -41,7 +44,7 @@
                     "name": "y",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 22,
+                        "id": 24,
                         "type": "float",
                         "const": false
                     }
@@ -51,7 +54,7 @@
                     "name": "z",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 22,
+                        "id": 24,
                         "type": "float",
                         "const": false
                     }
@@ -61,8 +64,8 @@
                 {
                     "kind": "Method",
                     "id": 0,
-                    "short_name": "setValue",
-                    "qualified_name": "Imath_2_4::Vec3<float>::setValue",
+                    "short_name": "normalize",
+                    "qualified_name": "Imath_2_5::Vec3<float>::normalize",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -79,106 +82,30 @@
                     "destructor": false,
                     "attributes": null,
                     "return": {
-                        "kind": "BuiltinType",
-                        "id": 0,
-                        "type": "void",
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 23,
+                            "const": true
+                        },
                         "const": false
                     },
-                    "params": [
-                        {
-                            "index": 0,
-                            "name": "a",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 22,
-                                "type": "float",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 1,
-                            "name": "b",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 22,
-                                "type": "float",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 2,
-                            "name": "c",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 22,
-                                "type": "float",
-                                "const": false
-                            },
-                            "attrs": []
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "kind": "Record",
-            "name": "Imath_2_4::Vec3<int>",
-            "short_name": "Vec3",
-            "namespaces": [
-                "Imath_2_4"
-            ],
-            "id": 31,
-            "size": 96,
-            "align": 32,
-            "alias": "V3i",
-            "attributes": [
-                "cppmm:valuetype"
-            ],
-            "fields": [
-                {
-                    "kind": "Field",
-                    "name": "x",
-                    "type": {
-                        "kind": "BuiltinType",
-                        "id": 26,
-                        "type": "int",
-                        "const": false
-                    }
+                    "params": null
                 },
-                {
-                    "kind": "Field",
-                    "name": "y",
-                    "type": {
-                        "kind": "BuiltinType",
-                        "id": 26,
-                        "type": "int",
-                        "const": false
-                    }
-                },
-                {
-                    "kind": "Field",
-                    "name": "z",
-                    "type": {
-                        "kind": "BuiltinType",
-                        "id": 26,
-                        "type": "int",
-                        "const": false
-                    }
-                }
-            ],
-            "methods": [
                 {
                     "kind": "Method",
                     "id": 0,
-                    "short_name": "setValue",
-                    "qualified_name": "Imath_2_4::Vec3<int>::setValue",
+                    "short_name": "normalized",
+                    "qualified_name": "Imath_2_5::Vec3<float>::normalized",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
                     "user_provided": true,
-                    "const": false,
+                    "const": true,
                     "virtual": false,
                     "overloaded_operator": false,
                     "copy_assignment_operator": false,
@@ -190,46 +117,13 @@
                     "destructor": false,
                     "attributes": null,
                     "return": {
-                        "kind": "BuiltinType",
-                        "id": 0,
-                        "type": "void",
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 23,
                         "const": false
                     },
-                    "params": [
-                        {
-                            "index": 0,
-                            "name": "a",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 26,
-                                "type": "int",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 1,
-                            "name": "b",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 26,
-                                "type": "int",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 2,
-                            "name": "c",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 26,
-                                "type": "int",
-                                "const": false
-                            },
-                            "attrs": []
-                        }
-                    ]
+                    "params": null
                 }
             ]
         }


### PR DESCRIPTION
Bring these back.

```
// Macro to define short conversion functions between C and C++ API types to
// save us from eye-gougingly verbose casts everywhere
#define CPPMM_DEFINE_POINTER_CASTS(CPPTYPE, CTYPE)          \
CPPTYPE* to_cpp(CTYPE* ptr) {                               \
    return reinterpret_cast<CPPTYPE*>(ptr);                 \
}                                                           \
                                                            \
const CPPTYPE* to_cpp(const CTYPE* ptr) {                   \
    return reinterpret_cast<const CPPTYPE*>(ptr);           \
}                                                           \
                                                            \
CTYPE* to_c(CPPTYPE* ptr) {                                 \
    return reinterpret_cast<CTYPE*>(ptr);                   \
}                                                           \
                                                            \
const CTYPE* to_c(const CPPTYPE* ptr) {                     \
    return reinterpret_cast<const CTYPE*>(ptr);             \
}                                                           \
                                                            \

template <typename TO, typename FROM>
TO bit_cast(FROM f) {
    static_assert(sizeof(TO) == sizeof(FROM), "sizes do not match");
    static_assert(alignof(TO) == alignof(FROM), "alignments do not match");

    TO result;
    memcpy((void*)&result, (void*)&f, sizeof(f));
    return result;
}
```
