### PR TITLE
Asttoc to casts

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ env LLVM_ROOT=</path/to/llvm/installation> cmake ..
 make
 ```
 
+### Build a debug build
+To build:
+```
+mkdir build && cd build
+env LLVM_ROOT=</path/to/llvm/installation> cmake -DCMAKE_BUILD_TYPE=Debug ..
+make
+```
+
 ### Test
 Some basic integration tests are in place using CTest. To run them you'll need to set the environment variables `OIIO_ROOT` and `OPENEXR_ROOT` to point to the relevant installations. Since the tests diff the output against reference you'll probably need the same versions (at least to minor versions) in order to not get spurious errors. Those versions are:
 ```

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -500,6 +500,8 @@ struct NodeFunction : public NodeAttributeHolder {
     std::vector<Param> params;
     bool in_binding = false;
     bool in_library = false;
+    bool private_ = false;
+
     NodeExprPtr body;
 
     NodeFunction(std::string qualified_name, NodeId id,

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -32,6 +32,7 @@ enum class NodeKind : uint32_t {
     FunctionCallExpr,
     MethodCallExpr,
     VarRefExpr,
+    VarDeclExpr,
     DerefExpr,
     RefExpr,
     CastExpr,
@@ -377,6 +378,28 @@ struct NodeVarRefExpr : public NodeExpr { // TODO LT: Added by luke, like clang 
 
     // A static method for creating this as a shared pointer
     using This = NodeVarRefExpr;
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
+};
+
+//------------------------------------------------------------------------------
+// NodeVarDeclExpr
+//------------------------------------------------------------------------------
+struct NodeVarDeclExpr : public NodeExpr { // TODO LT: Added by luke
+    NodeTypePtr var_type;
+    std::string var_name;
+
+    NodeVarDeclExpr(NodeTypePtr var_type, std::string var_name)
+        : NodeExpr(NodeKind::VarDeclExpr)
+        , var_type(var_type)
+        , var_name(var_name)
+    {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeVarDeclExpr;
     template<typename ... Args>
     static std::shared_ptr<This> n(Args&& ... args)
     {

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -568,6 +568,7 @@ struct NodeFunction : public NodeAttributeHolder {
     bool in_binding = false;
     bool in_library = false;
     bool private_ = false;
+    bool inline_ = false;
 
     NodeExprPtr body;
 

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -594,16 +594,19 @@ struct NodeFunction : public NodeAttributeHolder {
 struct NodeMethod : public NodeFunction {
     bool is_static;
     bool is_constructor;
+    bool is_copy_constructor;
     bool is_const;
 
     NodeMethod(std::string qualified_name, NodeId id,
                std::vector<std::string> attrs, std::string short_name,
                NodeTypePtr && return_type, std::vector<Param> && params,
-               bool is_static, bool is_constructor, bool is_const)
+               bool is_static, bool is_constructor, 
+               bool is_copy_constructor, bool is_const)
         : NodeFunction(qualified_name, id, attrs, short_name,
                        std::move(return_type), std::move(params))
           , is_static(is_static)
           , is_constructor(is_constructor)
+          , is_copy_constructor(is_copy_constructor)
           , is_const(is_const)
     {
         kind = NodeKind::Method;

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -29,6 +29,7 @@ enum class NodeKind : uint32_t {
     FunctionProtoType,
     Parm,
     Function,
+    AssignExpr,
     FunctionCallExpr,
     MethodCallExpr,
     VarRefExpr,
@@ -400,6 +401,28 @@ struct NodeVarDeclExpr : public NodeExpr { // TODO LT: Added by luke
 
     // A static method for creating this as a shared pointer
     using This = NodeVarDeclExpr;
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
+};
+
+//------------------------------------------------------------------------------
+// NodeAssignExpr
+//------------------------------------------------------------------------------
+struct NodeAssignExpr : public NodeExpr { // TODO LT: Added by luke
+    NodeExprPtr lhs;
+    NodeExprPtr rhs;
+
+    NodeAssignExpr(NodeExprPtr lhs, NodeExprPtr rhs)
+        : NodeExpr(NodeKind::AssignExpr)
+        , lhs(lhs)
+        , rhs(rhs)
+    {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeAssignExpr;
     template<typename ... Args>
     static std::shared_ptr<This> n(Args&& ... args)
     {

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -81,6 +81,7 @@ struct TranslationUnit {
     std::set<NodePtr> forward_decls;
 
     std::string header_filename;
+    std::string private_header_filename;
     std::set<std::string> source_includes;
     std::set<std::string> header_includes;
 
@@ -96,6 +97,7 @@ struct TranslationUnit {
         : filename(std::move(rhs.filename))
         , decls(std::move(rhs.decls))
         , header_filename(std::move(rhs.header_filename))
+        , private_header_filename(std::move(rhs.private_header_filename))
         , source_includes(std::move(rhs.source_includes))
     {}
 
@@ -103,6 +105,7 @@ struct TranslationUnit {
         filename = std::move(rhs.filename);
         decls = std::move(rhs.decls);
         header_filename = std::move(rhs.header_filename);
+        private_header_filename = std::move(rhs.private_header_filename);
         source_includes = std::move(rhs.source_includes);
     }
 

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -30,6 +30,7 @@ enum class NodeKind : uint32_t {
     Parm,
     Function,
     AssignExpr,
+    BlockExpr,
     FunctionCallExpr,
     MethodCallExpr,
     VarRefExpr,
@@ -508,6 +509,26 @@ struct NodeCastExpr : public NodeExpr { // TODO LT: Added by luke
 
     // A static method for creating this as a shared pointer
     using This = NodeCastExpr;
+    template<typename ... Args>
+    static std::shared_ptr<This> n(Args&& ... args)
+    {
+        return std::make_shared<This>(std::forward<Args>(args)...);
+    }
+};
+
+//------------------------------------------------------------------------------
+// NodeBlockExpr
+//------------------------------------------------------------------------------
+struct NodeBlockExpr : public NodeExpr { // TODO LT: Added by luke new () ();
+    std::vector<NodeExprPtr> expressions;
+
+    NodeBlockExpr(std::vector<NodeExprPtr> && expressions)
+        : NodeExpr(NodeKind::BlockExpr)
+        , expressions(expressions)
+    {}
+
+    // A static method for creating this as a shared pointer
+    using This = NodeBlockExpr;
     template<typename ... Args>
     static std::shared_ptr<This> n(Args&& ... args)
     {

--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -83,6 +83,7 @@ struct TranslationUnit {
     std::string header_filename;
     std::string private_header_filename;
     std::set<std::string> source_includes;
+    std::set<std::string> source_private_includes;
     std::set<std::string> header_includes;
 
     using Self = TranslationUnit;

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -359,25 +359,9 @@ NodeExprPtr convert_record_to(const NodeTypePtr & t, const NodeExprPtr & name)
     // different implementation.
     //
     auto reference = NodeRefExpr::n(NodeExprPtr(name));
-    auto type =\
-        NodePointerType::n(
-            PointerKind::Pointer,
-            std::move(NodeTypePtr(t)),
-            false
+    return NodeFunctionCallExpr::n("to_cpp_ref",
+                                   std::vector<NodeExprPtr>({ reference })
     );
-    auto inner = NodeCastExpr::n(
-        std::move(reference), std::move(type), "reinterpret");
-    return NodeDerefExpr::n(std::move(inner));
-
-    /*
-    // Above code could look like this later.
-    return DerefExpr::n(
-        CastExpr::n(
-            RefExpr::n(
-                VarRefExpr::n( name ) ),
-            PointerType::n( t, false ))
-    )
-    */
 }
 
 //------------------------------------------------------------------------------
@@ -392,24 +376,16 @@ NodeExprPtr convert_pointer_to(const NodeTypePtr & t, const NodeExprPtr & name)
     {
         case PointerKind::Pointer:
             {
-                auto type = NodeTypePtr(t);
-                return NodeCastExpr::n(NodeExprPtr(name),
-                                       std::move(type),
-                                       "reinterpret");
+                return NodeFunctionCallExpr::n("to_cpp",
+                                               std::vector<NodeExprPtr>({ name })
+                );
             }
         case PointerKind::RValueReference: // TODO LT: Add support for rvalue reference
         case PointerKind::Reference:
             {
-                auto pointee = NodeTypePtr(p->pointee_type);
-                auto type =\
-                    NodePointerType::n(
-                        PointerKind::Pointer,
-                        std::move(pointee),
-                        p->const_
+                return NodeFunctionCallExpr::n("to_cpp_ref",
+                                               std::vector<NodeExprPtr>({ name })
                 );
-                auto inner = NodeCastExpr::n(
-                    NodeExprPtr(name), std::move(type), "reinterpret");
-                return NodeDerefExpr::n(std::move(inner));
             }
         default:
             break;

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -419,14 +419,8 @@ NodeExprPtr convert_record_from(
                                  const NodeTypePtr & to_ptr,
                                  const NodeExprPtr & name)
 {
-    auto reference = NodeRefExpr::n(NodeExprPtr(name));
-    auto inner = NodeCastExpr::n(
-        std::move(reference), NodePointerType::n(PointerKind::Pointer,
-                                                 NodeTypePtr(to_ptr),
-                                                 false),
-        "reinterpret"
-    );
-    return NodeDerefExpr::n(std::move(inner));
+    return NodeFunctionCallExpr::n("to_c_copy",
+                                   std::vector<NodeExprPtr>({ name }));
 }
 
 //------------------------------------------------------------------------------
@@ -435,25 +429,17 @@ NodeExprPtr convert_pointer_from(
                                  const NodeTypePtr & to_ptr,
                                  const NodeExprPtr & name)
 {
-    // TODO LT: Assuming opaquebytes at the moment, opaqueptr will have a
-    // different implementation.
-    //
     auto from = static_cast<const NodePointerType*>(from_ptr.get());
 
     switch (from->pointer_kind)
     {
-        case PointerKind::Pointer:
-            {
-                return NodeCastExpr::n(NodeExprPtr(name),
-                                                      NodeTypePtr(to_ptr),
-                                                      "reinterpret");
-            }
         case PointerKind::RValueReference: // TODO LT: Add support for rvalue reference
+        case PointerKind::Pointer:
         case PointerKind::Reference:
             {
-                auto ref = NodeRefExpr::n(NodeExprPtr(name));
-                return NodeCastExpr::n(
-                    NodeExprPtr(name), NodeTypePtr(to_ptr), "reinterpret");
+                return NodeFunctionCallExpr::n("to_c",
+                                               std::vector<NodeExprPtr>({ name })
+                );
             }
         default:
             break;

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -315,19 +315,10 @@ Param self_param(const NodeRecord & c_record, bool const_)
 //------------------------------------------------------------------------------
 NodeExprPtr this_reference(const NodeRecord & cpp_record, bool const_)
 {
-    auto record = NodeRecordType::n(
-                    "", 0, cpp_record.name, cpp_record.id, const_
-    );
-    auto type = NodePointerType::n(
-                    PointerKind::Pointer,
-                    std::move(record), false 
-    );
-    auto self = NodeVarRefExpr::n("self");
-    auto cast = NodeCastExpr::n(std::move(self),
-                                std::move(type),
-                                "reinterpret");
-
-    return cast;
+    return NodeFunctionCallExpr::n("to_cpp",
+                                        std::vector<NodeExprPtr>({
+        NodeVarRefExpr::n("self")
+    }));
 }
 
 //------------------------------------------------------------------------------
@@ -515,10 +506,12 @@ NodeExprPtr opaquebytes_constructor_body(TypeRegistry & type_registry,
     }
 
     // Create the method call expression
-    return NodePlacementNewExpr::n(
-        NodeVarRefExpr::n("self"),
-        NodeFunctionCallExpr::n(cpp_method.short_name, args)
-    );
+    return NodeBlockExpr::n(
+                    std::vector<NodeExprPtr>({
+                        NodePlacementNewExpr::n(
+                            NodeVarRefExpr::n("self"),
+                            NodeFunctionCallExpr::n(cpp_method.short_name, args)
+    )}));
 }
 
 //------------------------------------------------------------------------------
@@ -557,8 +550,12 @@ NodeExprPtr opaquebytes_method_body(TypeRegistry & type_registry,
     }
     else
     {
-        return NodeReturnExpr::n(
-            convert_from(cpp_method.return_type, c_return, method_call));
+        return NodeBlockExpr::n(
+                    std::vector<NodeExprPtr>({
+                        NodeReturnExpr::n(
+                            convert_from(cpp_method.return_type,
+                                         c_return, method_call))
+        }));
     }
     //return method_call;
 }

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -706,11 +706,11 @@ void namespace_entry(TypeRegistry & type_registry, const NodePtr & cpp_node)
 }
 
 //------------------------------------------------------------------------------
-void opaquebytes_ref_to_cpp(TranslationUnit & c_tu,
-                            const NodeRecord & cpp_record,
-                            const NodeRecord & c_record,
-                            bool const_,
-                            PointerKind pointer_kind)
+void opaquebytes_to_cpp(TranslationUnit & c_tu,
+                        const NodeRecord & cpp_record,
+                        const NodeRecord & c_record,
+                        bool const_,
+                        PointerKind pointer_kind)
 {
     auto rhs =
         NodePointerType::n(
@@ -772,10 +772,10 @@ void opaquebytes_conversions(TranslationUnit & c_tu,
                              const NodeRecord & c_record)
 {
     // Conversions for going from cpp to c
-    opaquebytes_ref_to_cpp(c_tu, cpp_record, c_record, true, PointerKind::Reference);
-    opaquebytes_ref_to_cpp(c_tu, cpp_record, c_record, false, PointerKind::Reference);
-    opaquebytes_ref_to_cpp(c_tu, cpp_record, c_record, true, PointerKind::Pointer);
-    opaquebytes_ref_to_cpp(c_tu, cpp_record, c_record, false, PointerKind::Pointer);
+    opaquebytes_to_cpp(c_tu, cpp_record, c_record, true, PointerKind::Reference);
+    opaquebytes_to_cpp(c_tu, cpp_record, c_record, false, PointerKind::Reference);
+    opaquebytes_to_cpp(c_tu, cpp_record, c_record, true, PointerKind::Pointer);
+    opaquebytes_to_cpp(c_tu, cpp_record, c_record, false, PointerKind::Pointer);
 
     // Conversions for going from c to cpp
 }

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -773,6 +773,7 @@ void opaquebytes_to_cpp(TranslationUnit & c_tu,
 
     c_function->body = c_function_body;
     c_function->private_ = true;
+    c_function->inline_ = true;
 
     c_tu.decls.push_back(std::move(c_function));
 }
@@ -917,6 +918,7 @@ void opaquebytes_from_cpp_copy(TranslationUnit & c_tu,
 
     c_function->body = c_function_body;
     c_function->private_ = true;
+    c_function->inline_ = true;
 
     c_tu.decls.push_back(std::move(c_function));
 }

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -92,7 +92,7 @@ const NodeId PLACEHOLDER_ID = 0;
 const char * IGNORE = "cppmm:ignore";
 
 //------------------------------------------------------------------------------
-std::tuple<std::string, std::string>
+std::tuple<std::string, std::string, std::string>
              compute_c_filepath(const std::string & outdir,
                                const std::string & cpp_filepath)
 {
@@ -100,9 +100,13 @@ std::tuple<std::string, std::string>
     std::string _ext;
     pystring::os::path::splitext(root, _ext,
                                  pystring::os::path::basename(cpp_filepath));
+
+    const auto abs_root = pystring::os::path::join(outdir, root);
     
     return {root + ".h",
-            pystring::os::path::join(outdir, root) + ".cpp"};
+            abs_root + ".cpp",
+            root + "_private.h",
+    };
 }
 
 //------------------------------------------------------------------------------
@@ -764,9 +768,17 @@ void translation_unit_entries(
         generate::compute_c_filepath(output_directory,
                                      cpp_tu->filename);
 
+    enum Outputs {
+        Header = 0,
+        Source = 1,
+        PrivateHeader = 2,
+    };
+
     // Make the new translation unit
-    auto c_tu = TranslationUnit::new_(std::get<1>(filepaths));
-    c_tu->header_filename = header_file_include(std::get<0>(filepaths));
+    auto c_tu = TranslationUnit::new_(std::get<Source>(filepaths));
+    c_tu->header_filename = header_file_include(std::get<Header>(filepaths));
+    c_tu->private_header_filename =
+        header_file_include(std::get<PrivateHeader>(filepaths));
 
     // source includes -> source includes
     for (auto & i : cpp_tu->source_includes)

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -852,7 +852,6 @@ void opaquebytes_from_cpp(TranslationUnit & c_tu,
 }
 */
 
-/*
 //------------------------------------------------------------------------------
 void opaquebytes_from_cpp_copy(TranslationUnit & c_tu,
                                const NodeRecord & cpp_record,
@@ -860,7 +859,7 @@ void opaquebytes_from_cpp_copy(TranslationUnit & c_tu,
                                const NodePtr & copy_constructor_ptr)
 {
     const auto & copy_constructor =\
-        *static_cast<const NodeFunction*>(copy_constructor.get());
+        *static_cast<const NodeFunction*>(copy_constructor_ptr.get());
 
     auto rhs =
         NodePointerType::n(
@@ -905,15 +904,16 @@ void opaquebytes_from_cpp_copy(TranslationUnit & c_tu,
                         NodeVarRefExpr::n("result")
                     ),
                     NodeCastExpr::n(
+                        NodeRefExpr::n(
+                            NodeVarRefExpr::n("rhs")
+                        ),
                         NodePointerType::n(
                             PointerKind::Pointer,
                             NodeRecordType::n("", 0, c_record.name, c_record.id,
                                               true),
                             false
                         ),
-                        NodeRefExpr::n(
-                            NodeVarRefExpr::n("rhs")
-                        )
+                        "reinterpret"
                     )
                 })
             ),
@@ -937,7 +937,6 @@ void opaquebytes_from_cpp_copy(TranslationUnit & c_tu,
 
     c_tu.decls.push_back(std::move(c_function));
 }
-*/
 
 //------------------------------------------------------------------------------
 void opaquebytes_conversions(TranslationUnit & c_tu,
@@ -953,12 +952,10 @@ void opaquebytes_conversions(TranslationUnit & c_tu,
 
     // We need the copy constructor in order to be able to return records
     // by value
-    /*
     if(copy_constructor)
     {
         opaquebytes_from_cpp_copy(c_tu, cpp_record, c_record, copy_constructor);
     }
-    */
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -706,6 +706,13 @@ void namespace_entry(TypeRegistry & type_registry, const NodePtr & cpp_node)
 }
 
 //------------------------------------------------------------------------------
+void opaquebytes_conversions(TranslationUnit & c_tu,
+                             const NodeRecord & cpp_record,
+                             const NodeRecord & c_record)
+{
+}
+
+//------------------------------------------------------------------------------
 void record_detail(TypeRegistry & type_registry, TranslationUnit & c_tu,
                    const NodePtr & cpp_node)
 {
@@ -722,6 +729,13 @@ void record_detail(TypeRegistry & type_registry, TranslationUnit & c_tu,
     // Least safe and most restrictive in use, but easiest to implement.
     // So doing that first. Later will switch depending on the cppm attributes.
 
+    // Record
+    opaquebytes_record(c_record);
+
+    // Conversions
+    opaquebytes_conversions(c_tu, cpp_record, c_record);
+
+    // Methods
     opaquebytes_methods(type_registry, c_tu, cpp_record, c_record);
 }
 

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -532,18 +532,17 @@ NodeExprPtr opaquebytes_method_body(TypeRegistry & type_registry,
 
     if(is_void)
     {
-        return method_call;
-    }
-    else
-    {
         return NodeBlockExpr::n(
-                    std::vector<NodeExprPtr>({
-                        NodeReturnExpr::n(
-                            convert_from(cpp_method.return_type,
-                                         c_return, method_call))
+                    std::vector<NodeExprPtr>({method_call
         }));
     }
-    //return method_call;
+
+    return NodeBlockExpr::n(
+                std::vector<NodeExprPtr>({
+                    NodeReturnExpr::n(
+                        convert_from(cpp_method.return_type,
+                                     c_return, method_call))
+    }));
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -708,19 +708,20 @@ void namespace_entry(TypeRegistry & type_registry, const NodePtr & cpp_node)
 //------------------------------------------------------------------------------
 void opaquebytes_ref_to_c(TranslationUnit & c_tu,
                           const NodeRecord & cpp_record,
-                          const NodeRecord & c_record)
+                          const NodeRecord & c_record,
+                          bool const_)
 {
     auto rhs =
         NodePointerType::n(
             PointerKind::Reference,
-            NodeRecordType::n("", 0, cpp_record.name, cpp_record.id, true),
+            NodeRecordType::n("", 0, cpp_record.name, cpp_record.id, const_),
             false
     );
 
     auto c_return =
         NodePointerType::n(
             PointerKind::Pointer,
-                NodeRecordType::n("", 0, c_record.name, c_record.id, true),
+                NodeRecordType::n("", 0, c_record.name, c_record.id, const_),
     false);
 
     // Function body
@@ -754,7 +755,8 @@ void opaquebytes_conversions(TranslationUnit & c_tu,
                              const NodeRecord & cpp_record,
                              const NodeRecord & c_record)
 {
-    opaquebytes_ref_to_c(c_tu, cpp_record, c_record);
+    opaquebytes_ref_to_c(c_tu, cpp_record, c_record, true);
+    opaquebytes_ref_to_c(c_tu, cpp_record, c_record, false);
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -757,7 +757,9 @@ void opaquebytes_to_cpp(TranslationUnit & c_tu,
 
     // Function body
     auto c_function_body =
-        NodeReturnExpr::n(std::move(cast_expr));
+        NodeBlockExpr::n(std::vector<NodeExprPtr>({
+            NodeReturnExpr::n(std::move(cast_expr)),
+        }));
 
     // Add the new function to the translation unit
     std::vector<std::string> attrs;

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -869,23 +869,6 @@ void opaquebytes_from_cpp_copy(TranslationUnit & c_tu,
     );
 
     auto c_return = NodeRecordType::n("", 0, c_record.name, c_record.id, false);
-    auto bit_cast =
-        NodeFunctionCallExpr::n(
-            "memcpy",
-            std::vector<NodeExprPtr>({
-                NodeRefExpr::n(
-                    NodeVarRefExpr::n("result")
-                ),
-                NodeRefExpr::n(
-                    NodeVarRefExpr::n("rhs")
-                ),
-                NodeFunctionCallExpr::n("sizeof",
-                                        std::vector<NodeExprPtr>({
-                                            NodeVarRefExpr::n("rhs")
-                                        })
-                )
-            })
-    );
 
     // Function body
     auto c_function_body =

--- a/asttoc/src/cppmm_ast_add_c.cpp
+++ b/asttoc/src/cppmm_ast_add_c.cpp
@@ -184,6 +184,7 @@ void add_declaration(TranslationUnit & c_tu, const NodePtr & node_ptr,
             {
                 c_tu.header_includes.insert(r_tu->header_filename);
             }
+            c_tu.source_private_includes.insert(r_tu->private_header_filename);
         }
     }
 }

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -26,6 +26,7 @@ namespace {
     const char * ATTRIBUTES = "attributes";
     const char * CHILDREN = "children";
     const char * CONSTRUCTOR = "constructor";
+    const char * COPY_CONSTRUCTOR = "copy_constructor";
     const char * CONST = "const";
     const char * DECLS = "decls";
     const char * ENUM_C = "Enum";
@@ -186,6 +187,7 @@ NodeMethod read_method(const nln::json & json) {
     auto id = json[ID].get<Id>();
     auto static_ = json[STATIC].get<bool>();
     auto constructor = json[CONSTRUCTOR].get<bool>();
+    auto copy_constructor = json[COPY_CONSTRUCTOR].get<bool>();
     auto return_type = read_type(json[RETURN]);
     auto const_ = json[CONST].get<bool>();
 
@@ -196,7 +198,8 @@ NodeMethod read_method(const nln::json & json) {
 
     return NodeMethod(qualified_name, id, attrs, short_name,
                       std::move(return_type),
-                      std::move(params), static_, constructor, const_);
+                      std::move(params), static_, constructor, copy_constructor,
+                      const_);
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -219,8 +219,15 @@ NodePtr read_record(const TranslationUnit::Ptr & tu, const nln::json & json) {
     Id id = json[ID].get<Id>();
     auto size = json[SIZE].get<uint64_t>();
     auto align = json[ALIGN].get<uint64_t>();
-    auto name = json[NAME].get<std::string>();
-    auto alias = json[ALIAS].get<std::string>();
+    auto qual_name = json[NAME].get<std::string>();
+    auto name = json[SHORT_NAME].get<std::string>();
+ 
+    // Override the name with an alias if one is provided 
+    auto alias = json.find(ALIAS);
+    if( alias != json.end() )
+    {
+        name = alias->get<std::string>();
+    }
 
     // Namespaces
     std::vector<NodeId> namespaces;
@@ -231,7 +238,7 @@ NodePtr read_record(const TranslationUnit::Ptr & tu, const nln::json & json) {
 
     // Instantiate the translation unit
     auto result =\
-        NodeRecord::n(tu, name, id, _attrs, size, align, alias, namespaces);
+        NodeRecord::n(tu, qual_name, id, _attrs, size, align, name, namespaces);
 
     // Pull out the methods
     for (const auto & i : json[METHODS] ){

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -74,10 +74,10 @@ std::string convert_pointer_param(const NodeTypePtr & t,
     {
         case PointerKind::Pointer:
             return convert_param(p->pointee_type,
-                                 fmt::format("*{}", name));
+                                 fmt::format("* {}", name));
         case PointerKind::Reference:
             return convert_param(p->pointee_type,
-                                 fmt::format("&{}", name));
+                                 fmt::format("& {}", name));
         default:
             break;
     }

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -391,6 +391,11 @@ void write_private_header(const TranslationUnit & tu)
     auto out =
         fmt::output_file(compute_c_header_path(tu.filename, "_private.h"));
 
+    if(!tu.header_filename.empty())
+    {
+        out.print("{}\n\n", tu.header_filename);
+    }
+
 #if 0
     // Then all the private functions
     for(const auto & node : tu.decls)

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -70,8 +70,19 @@ std::string convert_pointer_param(const NodeTypePtr & t,
 {
     auto p = static_cast<const NodePointerType*>(t.get());
 
-    return convert_param(p->pointee_type,
-                         fmt::format("*{}", name));
+    switch(p->pointer_kind)
+    {
+        case PointerKind::Pointer:
+            return convert_param(p->pointee_type,
+                                 fmt::format("*{}", name));
+        case PointerKind::Reference:
+            return convert_param(p->pointee_type,
+                                 fmt::format("&{}", name));
+        default:
+            break;
+    }
+
+    return "";
 }
 
 //------------------------------------------------------------------------------

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -509,11 +509,6 @@ void write_private_header(const TranslationUnit & tu)
     auto out =
         fmt::output_file(compute_c_header_path(tu.filename, "_private.h"));
 
-    if(!tu.header_filename.empty())
-    {
-        out.print("{}\n\n", tu.header_filename);
-    }
-
     // Then all the private functions
     for(const auto & node : tu.decls)
     {

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -184,6 +184,7 @@ void write_function_dcl(fmt::ostream & out, const NodePtr & node, Access access)
     const bool private_ = (access == Access::Private);
     if(private_ == function.private_)
     {
+        out.print("\n");
         out.print("{}(", convert_param(function.return_type,
                                        function.name));
         write_params(out, function);
@@ -409,6 +410,7 @@ void write_function_bdy(fmt::ostream & out, const NodePtr & node, Access access)
     const bool private_ = (access == Access::Private);
     if(private_ == function.private_)
     {
+        out.print("\n");
         if(function.inline_)
         {
             out.print("inline ");

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -29,12 +29,13 @@ void indent(fmt::ostream & out, const size_t depth)
 }
 
 //------------------------------------------------------------------------------
-std::string compute_c_header_path(const std::string & path)
+std::string compute_c_header_path(const std::string & path,
+                                  const char * extension)
 {
     std::string _;
     std::string result;
     pystring::os::path::splitext(result, _, path);
-    result += ".h";
+    result += extension;
 
     return result;
 }
@@ -364,9 +365,49 @@ void write_header_includes(fmt::ostream & out, const TranslationUnit & tu)
 }
 
 //------------------------------------------------------------------------------
+void write_source_includes(fmt::ostream & out, const TranslationUnit & tu)
+{
+    if(!tu.header_filename.empty())
+    {
+        out.print("{}\n\n", tu.header_filename);
+    }
+
+    for(const auto & i : tu.source_includes)
+    {
+        out.print("{}\n", i);
+    }
+
+    if(!tu.private_header_filename.empty())
+    {
+        out.print("{}\n", tu.private_header_filename);
+    }
+
+    out.print("\n");
+}
+
+//------------------------------------------------------------------------------
+void write_private_header(const TranslationUnit & tu)
+{
+    auto out =
+        fmt::output_file(compute_c_header_path(tu.filename, "_private.h"));
+
+#if 0
+    // Then all the private functions
+    for(const auto & node : tu.decls)
+    {
+        if (node->kind == NodeKind::Function)
+        {
+            out.print("\n");
+            write_function(out, node);
+        }
+    }
+#endif
+}
+
+//------------------------------------------------------------------------------
 void write_header(const TranslationUnit & tu)
 {
-    auto out = fmt::output_file(compute_c_header_path(tu.filename));
+    auto out = fmt::output_file(compute_c_header_path(tu.filename, ".h"));
 
     // Write all the includes needed in the header file
     write_header_includes(out, tu);
@@ -401,22 +442,6 @@ void write_header(const TranslationUnit & tu)
 }
 
 //------------------------------------------------------------------------------
-void write_source_includes(fmt::ostream & out, const TranslationUnit & tu)
-{
-    if(!tu.header_filename.empty())
-    {
-        out.print("{}\n\n", tu.header_filename);
-    }
-
-    for(const auto & i : tu.source_includes)
-    {
-        out.print("{}\n", i);
-    }
-
-    out.print("\n");
-}
-
-//------------------------------------------------------------------------------
 void write_source(const TranslationUnit & tu)
 {
     auto out = fmt::output_file(tu.filename);
@@ -438,6 +463,7 @@ void write_source(const TranslationUnit & tu)
 void write_translation_unit(const TranslationUnit & tu)
 {
     write_header(tu);
+    write_private_header(tu);
     write_source(tu);
 }
 

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -377,6 +377,11 @@ void write_source_includes(fmt::ostream & out, const TranslationUnit & tu)
         out.print("{}\n", i);
     }
 
+    for(const auto & i : tu.source_private_includes)
+    {
+        out.print("{}\n", i);
+    }
+
     if(!tu.private_header_filename.empty())
     {
         out.print("{}\n", tu.private_header_filename);

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -19,6 +19,12 @@ class Root;
 
 namespace write
 {
+
+enum class Access : uint32_t {
+    Private = 0,
+    Public
+};
+
 //------------------------------------------------------------------------------
 void indent(fmt::ostream & out, const size_t depth)
 {
@@ -154,15 +160,19 @@ void write_params(fmt::ostream & out, const NodeFunction & function)
 }
 
 //------------------------------------------------------------------------------
-void write_function(fmt::ostream & out, const NodePtr & node)
+void write_function(fmt::ostream & out, const NodePtr & node, Access access)
 {
     const NodeFunction & function =
         *static_cast<const NodeFunction*>(node.get());
 
-    out.print("{}(", convert_param(function.return_type,
-                                   function.name));
-    write_params(out, function);
-    out.print(");\n");
+    const bool private_ = (access == Access::Private);
+    if(private_ == function.private_)
+    {
+        out.print("{}(", convert_param(function.return_type,
+                                       function.name));
+        write_params(out, function);
+        out.print(");\n");
+    }
 }
 
 void write_expression(fmt::ostream & out, size_t depth,
@@ -401,17 +411,15 @@ void write_private_header(const TranslationUnit & tu)
         out.print("{}\n\n", tu.header_filename);
     }
 
-#if 0
     // Then all the private functions
     for(const auto & node : tu.decls)
     {
         if (node->kind == NodeKind::Function)
         {
             out.print("\n");
-            write_function(out, node);
+            write_function(out, node, Access::Private);
         }
     }
-#endif
 }
 
 //------------------------------------------------------------------------------
@@ -440,13 +448,13 @@ void write_header(const TranslationUnit & tu)
         }
     }
 
-    // Then all the functions
+    // Then all the public functions
     for(const auto & node : tu.decls)
     {
         if (node->kind == NodeKind::Function)
         {
             out.print("\n");
-            write_function(out, node);
+            write_function(out, node, Access::Public);
         }
     }
 }

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -207,25 +207,19 @@ void write_function_call_arguments(fmt::ostream & out,
     else
     {
         // start
-        out.print("(\n");
+        out.print("(");
 
         // First argument
-        indent(out, depth);
-        out.print(" ");
         write_expression(out, depth, function_call.args[0]);
-        out.print("\n");
 
         // All the others
         for(size_t i=1; i < function_call.args.size(); ++i)
         {
-            indent(out, depth);
-            out.print(",");
+            out.print(", ");
             write_expression(out, depth, function_call.args[i]);
-            out.print("\n");
         }
 
         // start
-        indent(out, depth);
         out.print(")");
     }
 }
@@ -251,9 +245,7 @@ void write_expression_method_call(fmt::ostream & out,
 
     out.print("(");
     write_expression(out, depth, method_call.this_);
-    out.print(") -> \n");
-    indent(out, depth + 1);
-    out.print("{}", method_call.name);
+    out.print(") -> {}", method_call.name);
     write_function_call_arguments(out, depth, method_call);
 }
 

--- a/asttoc/src/cppmm_ast_write.cpp
+++ b/asttoc/src/cppmm_ast_write.cpp
@@ -428,7 +428,6 @@ void write_function_bdy(fmt::ostream & out, const NodePtr & node, Access access)
         out.print(")\n");
         out.print("{{\n");
         write_expression(out, 1, function.body);
-        out.print(";\n");
         out.print("}}\n");
     }
 }

--- a/bind.sh
+++ b/bind.sh
@@ -1,10 +1,14 @@
+project=imath
+
 pushd build
-./cppmm ../test/std/bind -u              \
-    -o ../test/std/ref                   \
-    -i $PWD/../test/std/bind             \
+./cppmm ../test/$project/bind -u              \
+    -o ../test/$project/ref                   \
+    -i $PWD/../test/$project/bind             \
     -rust-sys $PWD/../test/std/rust      \
     --                                   \
-    -I../test/std/bind                   \
+    -I../test/                   \
+    -I../test/$project/bind                   \
+    -I/Volumes/src/packages/usr/local/include \
     -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk \
     -isystem /Volumes/src/clang+llvm-11.0.0-x86_64-apple-darwin/include/c++/v1 \
     -isystem /Volumes/src/clang+llvm-11.0.0-x86_64-apple-darwin/lib/clang/11.0.0/include

--- a/test/imath/bind/imath_vec.cpp
+++ b/test/imath/bind/imath_vec.cpp
@@ -11,17 +11,20 @@ template <class T> class Vec3 {
 public:
     // This allows us to see through to the type in Imath
     using BoundType = ::Imath::Vec3<T>;
-#if 0
+
+    Vec3( );
+    Vec3( const ::Imath::Vec3<T>& v );
 
     // we're not actually paying any attention to the method declarations yet
     // no matching
+    /*
     bool equalWithAbsError(const Vec3<T>& v, T e) const;
     bool equalWithRelError(const Vec3<T>& v, T e) const;
+    */
 
     T dot(const ::Imath::Vec3<T>& v) const;
     ::Imath::Vec3<T> cross(const ::Imath::Vec3<T>& v) const;
     const ::Imath::Vec3<T>& operator+=(const ::Imath::Vec3<T>& v) CPPMM_RENAME(op_iadd) ;
-#endif
 
     const ::Imath::Vec3<T>& normalize();
     ::Imath::Vec3<T> normalized() const;

--- a/test/imath/ref/ast/imath_box.json
+++ b/test/imath/ref/ast/imath_box.json
@@ -1,20 +1,23 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_box.cpp",
+    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_box.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathBox.h>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "/home/anders/packages/openexr/2.5.5/include"
+        "../test/",
+        "../test/imath/bind",
+        "/Volumes/src/packages/usr/local/include",
+        "/Volumes/src/cppmm/build/../test/imath/bind"
     ],
     "id": 5,
     "decls": [
         {
             "kind": "Namespace",
-            "name": "Imath_2_5",
+            "name": "Imath_2_4",
             "id": 6,
-            "short_name": "Imath_2_5"
+            "short_name": "Imath_2_4"
         },
         {
             "kind": "Record",
@@ -37,8 +40,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 1,
-                        "type": "Imath_2_5::Vec3<float>",
-                        "record": 24,
+                        "type": "Imath_2_4::Vec3<float>",
+                        "record": 25,
                         "const": false
                     }
                 },
@@ -48,8 +51,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 1,
-                        "type": "Imath_2_5::Vec3<float>",
-                        "record": 24,
+                        "type": "Imath_2_4::Vec3<float>",
+                        "record": 25,
                         "const": false
                     }
                 }
@@ -59,7 +62,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -92,8 +95,8 @@
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 1,
-                                    "type": "Imath_2_5::Vec3<float>",
-                                    "record": 24,
+                                    "type": "Imath_2_4::Vec3<float>",
+                                    "record": 25,
                                     "const": true
                                 },
                                 "const": false
@@ -106,7 +109,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -139,7 +142,7 @@
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 3,
-                                    "type": "Imath_2_5::Box<Imath::Vec3<float> >",
+                                    "type": "Imath_2_4::Box<Imath::Vec3<float> >",
                                     "record": 7,
                                     "const": true
                                 },
@@ -172,8 +175,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 14,
-                        "type": "Imath_2_5::Vec3<int>",
-                        "record": -1,
+                        "type": "Imath_2_4::Vec3<int>",
+                        "record": 32,
                         "const": false
                     }
                 },
@@ -183,8 +186,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 14,
-                        "type": "Imath_2_5::Vec3<int>",
-                        "record": -1,
+                        "type": "Imath_2_4::Vec3<int>",
+                        "record": 32,
                         "const": false
                     }
                 }
@@ -194,7 +197,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -223,12 +226,12 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 15,
-                                "type": "const class Imath_2_5::Vec3<int> &",
+                                "type": "const class Imath_2_4::Vec3<int> &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 14,
-                                    "type": "Imath_2_5::Vec3<int>",
-                                    "record": -1,
+                                    "type": "Imath_2_4::Vec3<int>",
+                                    "record": 32,
                                     "const": true
                                 },
                                 "const": false
@@ -241,7 +244,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -270,11 +273,11 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 17,
-                                "type": "const class Imath_2_5::Box<Imath::Vec3<int> > &",
+                                "type": "const class Imath_2_4::Box<Imath::Vec3<int> > &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 16,
-                                    "type": "Imath_2_5::Box<Imath::Vec3<int> >",
+                                    "type": "Imath_2_4::Box<Imath::Vec3<int> >",
                                     "record": 18,
                                     "const": true
                                 },

--- a/test/imath/ref/ast/imath_box.json
+++ b/test/imath/ref/ast/imath_box.json
@@ -1,23 +1,20 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_box.cpp",
+    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_box.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathBox.h>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "../test/",
-        "../test/imath/bind",
-        "/Volumes/src/packages/usr/local/include",
-        "/Volumes/src/cppmm/build/../test/imath/bind"
+        "/home/anders/packages/openexr/2.5.5/include"
     ],
     "id": 5,
     "decls": [
         {
             "kind": "Namespace",
-            "name": "Imath_2_4",
+            "name": "Imath_2_5",
             "id": 6,
-            "short_name": "Imath_2_4"
+            "short_name": "Imath_2_5"
         },
         {
             "kind": "Record",
@@ -40,8 +37,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 1,
-                        "type": "Imath_2_4::Vec3<float>",
-                        "record": 25,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 24,
                         "const": false
                     }
                 },
@@ -51,8 +48,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 1,
-                        "type": "Imath_2_4::Vec3<float>",
-                        "record": 25,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 24,
                         "const": false
                     }
                 }
@@ -62,7 +59,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float> >::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -95,8 +92,8 @@
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 1,
-                                    "type": "Imath_2_4::Vec3<float>",
-                                    "record": 25,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 24,
                                     "const": true
                                 },
                                 "const": false
@@ -109,7 +106,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float> >::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -142,7 +139,7 @@
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 3,
-                                    "type": "Imath_2_4::Box<Imath::Vec3<float> >",
+                                    "type": "Imath_2_5::Box<Imath::Vec3<float> >",
                                     "record": 7,
                                     "const": true
                                 },
@@ -175,8 +172,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 14,
-                        "type": "Imath_2_4::Vec3<int>",
-                        "record": 32,
+                        "type": "Imath_2_5::Vec3<int>",
+                        "record": -1,
                         "const": false
                     }
                 },
@@ -186,8 +183,8 @@
                     "type": {
                         "kind": "RecordType",
                         "id": 14,
-                        "type": "Imath_2_4::Vec3<int>",
-                        "record": 32,
+                        "type": "Imath_2_5::Vec3<int>",
+                        "record": -1,
                         "const": false
                     }
                 }
@@ -197,7 +194,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int> >::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -226,12 +223,12 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 15,
-                                "type": "const class Imath_2_4::Vec3<int> &",
+                                "type": "const class Imath_2_5::Vec3<int> &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 14,
-                                    "type": "Imath_2_4::Vec3<int>",
-                                    "record": 32,
+                                    "type": "Imath_2_5::Vec3<int>",
+                                    "record": -1,
                                     "const": true
                                 },
                                 "const": false
@@ -244,7 +241,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int> >::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -273,11 +270,11 @@
                             "type": {
                                 "kind": "Reference",
                                 "id": 17,
-                                "type": "const class Imath_2_4::Box<Imath::Vec3<int> > &",
+                                "type": "const class Imath_2_5::Box<Imath::Vec3<int> > &",
                                 "pointee": {
                                     "kind": "RecordType",
                                     "id": 16,
-                                    "type": "Imath_2_4::Box<Imath::Vec3<int> >",
+                                    "type": "Imath_2_5::Box<Imath::Vec3<int> >",
                                     "record": 18,
                                     "const": true
                                 },

--- a/test/imath/ref/ast/imath_box.json
+++ b/test/imath/ref/ast/imath_box.json
@@ -1,12 +1,15 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_box.cpp",
+    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_box.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathBox.h>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "/home/anders/packages/openexr/2.5.5/include"
+        "../test/",
+        "../test/imath/bind",
+        "/Volumes/src/packages/usr/local/include",
+        "/Volumes/src/cppmm/build/../test/imath/bind"
     ],
     "id": 5,
     "decls": [
@@ -38,7 +41,7 @@
                         "kind": "RecordType",
                         "id": 1,
                         "type": "Imath_2_5::Vec3<float>",
-                        "record": 24,
+                        "record": 25,
                         "const": false
                     }
                 },
@@ -49,7 +52,7 @@
                         "kind": "RecordType",
                         "id": 1,
                         "type": "Imath_2_5::Vec3<float>",
-                        "record": 24,
+                        "record": 25,
                         "const": false
                     }
                 }
@@ -59,7 +62,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -93,7 +96,7 @@
                                     "kind": "RecordType",
                                     "id": 1,
                                     "type": "Imath_2_5::Vec3<float>",
-                                    "record": 24,
+                                    "record": 25,
                                     "const": true
                                 },
                                 "const": false
@@ -106,7 +109,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<float>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -194,7 +197,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,
@@ -241,7 +244,7 @@
                     "kind": "Method",
                     "id": 0,
                     "short_name": "extendBy",
-                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int> >::extendBy",
+                    "qualified_name": "Imath_2_5::Box<Imath_2_5::Vec3<int>>::extendBy",
                     "in_binding": true,
                     "in_library": false,
                     "static": false,

--- a/test/imath/ref/ast/imath_vec.json
+++ b/test/imath/ref/ast/imath_vec.json
@@ -1,15 +1,18 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_vec.cpp",
+    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_vec.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathVec.h>",
         "#include <vector>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "/home/anders/packages/openexr/2.5.5/include"
+        "../test/",
+        "../test/imath/bind",
+        "/Volumes/src/packages/usr/local/include",
+        "/Volumes/src/cppmm/build/../test/imath/bind"
     ],
-    "id": 23,
+    "id": 24,
     "decls": [
         {
             "kind": "Namespace",
@@ -24,7 +27,7 @@
             "namespaces": [
                 6
             ],
-            "id": 24,
+            "id": 25,
             "size": 96,
             "align": 32,
             "alias": "V3f",
@@ -37,7 +40,7 @@
                     "name": "x",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 25,
+                        "id": 23,
                         "type": "float",
                         "const": false
                     }
@@ -47,7 +50,7 @@
                     "name": "y",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 25,
+                        "id": 23,
                         "type": "float",
                         "const": false
                     }
@@ -57,13 +60,916 @@
                     "name": "z",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 25,
+                        "id": 23,
                         "type": "float",
                         "const": false
                     }
                 }
             ],
             "methods": [
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "Vec3",
+                    "qualified_name": "Imath_2_5::Vec3<float>::Vec3",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": true,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "BuiltinType",
+                        "id": 0,
+                        "type": "void",
+                        "const": false
+                    },
+                    "params": null
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "Vec3",
+                    "qualified_name": "Imath_2_5::Vec3<float>::Vec3",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": true,
+                    "copy_constructor": true,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "BuiltinType",
+                        "id": 0,
+                        "type": "void",
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "Vec3",
+                    "qualified_name": "Imath_2_5::Vec3<float>::Vec3",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": true,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "BuiltinType",
+                        "id": 0,
+                        "type": "void",
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "dot",
+                    "qualified_name": "Imath_2_5::Vec3<float>::dot",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "BuiltinType",
+                        "id": 23,
+                        "type": "float",
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "cross",
+                    "qualified_name": "Imath_2_5::Vec3<float>::cross",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator+=",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator+=",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:op_iadd"
+                    ],
+                    "return": {
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 25,
+                            "const": true
+                        },
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator+",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator+",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator-=",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator-=",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 25,
+                            "const": true
+                        },
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator-",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator-",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:op_sub"
+                    ],
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator-",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator-",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:op_neg"
+                    ],
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": null
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator*=",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator*=",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:op_neg"
+                    ],
+                    "return": {
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 25,
+                            "const": true
+                        },
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator*=",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator*=",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:mul_assign_t",
+                        "cppmm:rename:op_neg"
+                    ],
+                    "return": {
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 25,
+                            "const": true
+                        },
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "a",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator*",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator*",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator*",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator*",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:mul_t"
+                    ],
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "a",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator/=",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator/=",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 25,
+                            "const": true
+                        },
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator/=",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator/=",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": false,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:div_assign_t"
+                    ],
+                    "return": {
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 25,
+                            "const": true
+                        },
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "a",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator/",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator/",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "v",
+                            "type": {
+                                "kind": "Reference",
+                                "id": 2,
+                                "type": "const class Imath_2_5::Vec3<float> &",
+                                "pointee": {
+                                    "kind": "RecordType",
+                                    "id": 1,
+                                    "type": "Imath_2_5::Vec3<float>",
+                                    "record": 25,
+                                    "const": true
+                                },
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "operator/",
+                    "qualified_name": "Imath_2_5::Vec3<float>::operator/",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": true,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": [
+                        "cppmm:rename:div_t"
+                    ],
+                    "return": {
+                        "kind": "RecordType",
+                        "id": 1,
+                        "type": "Imath_2_5::Vec3<float>",
+                        "record": 25,
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "a",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "length",
+                    "qualified_name": "Imath_2_5::Vec3<float>::length",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "BuiltinType",
+                        "id": 23,
+                        "type": "float",
+                        "const": false
+                    },
+                    "params": null
+                },
+                {
+                    "kind": "Method",
+                    "id": 0,
+                    "short_name": "length2",
+                    "qualified_name": "Imath_2_5::Vec3<float>::length2",
+                    "in_binding": true,
+                    "in_library": false,
+                    "static": false,
+                    "user_provided": true,
+                    "const": true,
+                    "virtual": false,
+                    "overloaded_operator": false,
+                    "copy_assignment_operator": false,
+                    "move_assignment_operator": false,
+                    "constructor": false,
+                    "copy_constructor": false,
+                    "move_constructor": false,
+                    "conversion_decl": false,
+                    "destructor": false,
+                    "attributes": null,
+                    "return": {
+                        "kind": "BuiltinType",
+                        "id": 23,
+                        "type": "float",
+                        "const": false
+                    },
+                    "params": null
+                },
                 {
                     "kind": "Method",
                     "id": 0,
@@ -92,7 +998,7 @@
                             "kind": "RecordType",
                             "id": 1,
                             "type": "Imath_2_5::Vec3<float>",
-                            "record": 24,
+                            "record": 25,
                             "const": true
                         },
                         "const": false
@@ -123,7 +1029,7 @@
                         "kind": "RecordType",
                         "id": 1,
                         "type": "Imath_2_5::Vec3<float>",
-                        "record": 24,
+                        "record": 25,
                         "const": false
                     },
                     "params": null

--- a/test/imath/ref/ast/imath_vec.json
+++ b/test/imath/ref/ast/imath_vec.json
@@ -1,21 +1,24 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_vec.cpp",
+    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_vec.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathVec.h>",
         "#include <vector>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "/home/anders/packages/openexr/2.5.5/include"
+        "../test/",
+        "../test/imath/bind",
+        "/Volumes/src/packages/usr/local/include",
+        "/Volumes/src/cppmm/build/../test/imath/bind"
     ],
-    "id": 23,
+    "id": 24,
     "decls": [
         {
             "kind": "Namespace",
-            "name": "Imath_2_5",
+            "name": "Imath_2_4",
             "id": 6,
-            "short_name": "Imath_2_5"
+            "short_name": "Imath_2_4"
         },
         {
             "kind": "Record",
@@ -24,7 +27,7 @@
             "namespaces": [
                 6
             ],
-            "id": 24,
+            "id": 25,
             "size": 96,
             "align": 32,
             "alias": "V3f",
@@ -37,7 +40,7 @@
                     "name": "x",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 25,
+                        "id": 23,
                         "type": "float",
                         "const": false
                     }
@@ -47,7 +50,7 @@
                     "name": "y",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 25,
+                        "id": 23,
                         "type": "float",
                         "const": false
                     }
@@ -57,7 +60,7 @@
                     "name": "z",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 25,
+                        "id": 23,
                         "type": "float",
                         "const": false
                     }
@@ -85,20 +88,97 @@
                     "destructor": false,
                     "attributes": null,
                     "return": {
-                        "kind": "Reference",
-                        "id": 2,
-                        "type": "const class Imath_2_5::Vec3<float> &",
-                        "pointee": {
-                            "kind": "RecordType",
-                            "id": 1,
-                            "type": "Imath_2_5::Vec3<float>",
-                            "record": 24,
-                            "const": true
+                        "kind": "BuiltinType",
+                        "id": 0,
+                        "type": "void",
+                        "const": false
+                    },
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "a",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
                         },
+                        {
+                            "index": 1,
+                            "name": "b",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
+                        },
+                        {
+                            "index": 2,
+                            "name": "c",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 23,
+                                "type": "float",
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "kind": "Record",
+            "name": "Imath_2_4::Vec3<int>",
+            "short_name": "Vec3",
+            "namespaces": [
+                6
+            ],
+            "id": 32,
+            "size": 96,
+            "align": 32,
+            "alias": "V3i",
+            "attributes": [
+                "cppmm:valuetype"
+            ],
+            "fields": [
+                {
+                    "kind": "Field",
+                    "name": "x",
+                    "type": {
+                        "kind": "BuiltinType",
+                        "id": 27,
+                        "type": "int",
+                        "const": false
+                    }
+                },
+                {
+                    "kind": "Field",
+                    "name": "y",
+                    "type": {
+                        "kind": "BuiltinType",
+                        "id": 27,
+                        "type": "int",
                         "const": false
                     },
                     "params": null
                 },
+                {
+                    "kind": "Field",
+                    "name": "z",
+                    "type": {
+                        "kind": "BuiltinType",
+                        "id": 27,
+                        "type": "int",
+                        "const": false
+                    }
+                }
+            ],
+            "methods": [
                 {
                     "kind": "Method",
                     "id": 0,
@@ -123,10 +203,44 @@
                         "kind": "RecordType",
                         "id": 1,
                         "type": "Imath_2_5::Vec3<float>",
-                        "record": 24,
+                        "record": 23,
                         "const": false
                     },
-                    "params": null
+                    "params": [
+                        {
+                            "index": 0,
+                            "name": "a",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 27,
+                                "type": "int",
+                                "const": false
+                            },
+                            "attrs": []
+                        },
+                        {
+                            "index": 1,
+                            "name": "b",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 27,
+                                "type": "int",
+                                "const": false
+                            },
+                            "attrs": []
+                        },
+                        {
+                            "index": 2,
+                            "name": "c",
+                            "type": {
+                                "kind": "BuiltinType",
+                                "id": 27,
+                                "type": "int",
+                                "const": false
+                            },
+                            "attrs": []
+                        }
+                    ]
                 }
             ]
         }

--- a/test/imath/ref/ast/imath_vec.json
+++ b/test/imath/ref/ast/imath_vec.json
@@ -1,24 +1,21 @@
 {
     "kind": "TranslationUnit",
-    "filename": "/Volumes/src/cppmm/test/imath/bind/imath_vec.cpp",
+    "filename": "/home/anders/code/cppmm/test/imath/bind/imath_vec.cpp",
     "source_includes": [
         "#include <OpenEXR/ImathVec.h>",
         "#include <vector>",
         "#include <cppmm_bind.hpp>"
     ],
     "include_paths": [
-        "../test/",
-        "../test/imath/bind",
-        "/Volumes/src/packages/usr/local/include",
-        "/Volumes/src/cppmm/build/../test/imath/bind"
+        "/home/anders/packages/openexr/2.5.5/include"
     ],
-    "id": 24,
+    "id": 23,
     "decls": [
         {
             "kind": "Namespace",
-            "name": "Imath_2_4",
+            "name": "Imath_2_5",
             "id": 6,
-            "short_name": "Imath_2_4"
+            "short_name": "Imath_2_5"
         },
         {
             "kind": "Record",
@@ -27,7 +24,7 @@
             "namespaces": [
                 6
             ],
-            "id": 25,
+            "id": 24,
             "size": 96,
             "align": 32,
             "alias": "V3f",
@@ -40,7 +37,7 @@
                     "name": "x",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 23,
+                        "id": 25,
                         "type": "float",
                         "const": false
                     }
@@ -50,7 +47,7 @@
                     "name": "y",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 23,
+                        "id": 25,
                         "type": "float",
                         "const": false
                     }
@@ -60,7 +57,7 @@
                     "name": "z",
                     "type": {
                         "kind": "BuiltinType",
-                        "id": 23,
+                        "id": 25,
                         "type": "float",
                         "const": false
                     }
@@ -88,97 +85,20 @@
                     "destructor": false,
                     "attributes": null,
                     "return": {
-                        "kind": "BuiltinType",
-                        "id": 0,
-                        "type": "void",
-                        "const": false
-                    },
-                    "params": [
-                        {
-                            "index": 0,
-                            "name": "a",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 23,
-                                "type": "float",
-                                "const": false
-                            },
-                            "attrs": []
+                        "kind": "Reference",
+                        "id": 2,
+                        "type": "const class Imath_2_5::Vec3<float> &",
+                        "pointee": {
+                            "kind": "RecordType",
+                            "id": 1,
+                            "type": "Imath_2_5::Vec3<float>",
+                            "record": 24,
+                            "const": true
                         },
-                        {
-                            "index": 1,
-                            "name": "b",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 23,
-                                "type": "float",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 2,
-                            "name": "c",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 23,
-                                "type": "float",
-                                "const": false
-                            },
-                            "attrs": []
-                        }
-                    ]
-                }
-            ]
-        },
-        {
-            "kind": "Record",
-            "name": "Imath_2_4::Vec3<int>",
-            "short_name": "Vec3",
-            "namespaces": [
-                6
-            ],
-            "id": 32,
-            "size": 96,
-            "align": 32,
-            "alias": "V3i",
-            "attributes": [
-                "cppmm:valuetype"
-            ],
-            "fields": [
-                {
-                    "kind": "Field",
-                    "name": "x",
-                    "type": {
-                        "kind": "BuiltinType",
-                        "id": 27,
-                        "type": "int",
-                        "const": false
-                    }
-                },
-                {
-                    "kind": "Field",
-                    "name": "y",
-                    "type": {
-                        "kind": "BuiltinType",
-                        "id": 27,
-                        "type": "int",
                         "const": false
                     },
                     "params": null
                 },
-                {
-                    "kind": "Field",
-                    "name": "z",
-                    "type": {
-                        "kind": "BuiltinType",
-                        "id": 27,
-                        "type": "int",
-                        "const": false
-                    }
-                }
-            ],
-            "methods": [
                 {
                     "kind": "Method",
                     "id": 0,
@@ -203,44 +123,10 @@
                         "kind": "RecordType",
                         "id": 1,
                         "type": "Imath_2_5::Vec3<float>",
-                        "record": 23,
+                        "record": 24,
                         "const": false
                     },
-                    "params": [
-                        {
-                            "index": 0,
-                            "name": "a",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 27,
-                                "type": "int",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 1,
-                            "name": "b",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 27,
-                                "type": "int",
-                                "const": false
-                            },
-                            "attrs": []
-                        },
-                        {
-                            "index": 2,
-                            "name": "c",
-                            "type": {
-                                "kind": "BuiltinType",
-                                "id": 27,
-                                "type": "int",
-                                "const": false
-                            },
-                            "attrs": []
-                        }
-                    ]
+                    "params": null
                 }
             ]
         }


### PR DESCRIPTION
Brings the to_cpp and to_c functions back online, am directly generating those in a private header per record, which is referenced by any wrapping method that needs it.

Replacing the bit cast with to_c_copy which calls the copy constructor (if it has one).

Have tested with oiio + imath tests we have at the moment.