### PR TITLE
cmake: install astgen and asttoc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(cppmm)
+project(cppmm LANGUAGES CXX)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,10 @@ find_package(Clang REQUIRED CONFIG)
 
 # Use the same C++ standard as LLVM does
 set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
-
+# Generate compile-commands.json for use by editors/IDEs.
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+# Simplify the installation messages.
+set(CMAKE_INSTALL_MESSAGE LAZY)
 
 # Installation directory for cppmm data files (share/cppmm).
 set(CMAKE_INSTALL_PACKAGE_DATADIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(cppmm)
 
+include(GNUInstallDirs)
+
 set(LLVM_ROOT $ENV{LLVM_ROOT})
 set(CMAKE_PREFIX_PATH "${LLVM_ROOT}/lib/cmake/clang")
 find_package(Clang REQUIRED CONFIG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,14 @@ set(CMAKE_CXX_STANDARD 14 CACHE STRING "")
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Installation directory for cppmm data files (share/cppmm).
+set(CMAKE_INSTALL_PACKAGE_DATADIR "${CMAKE_INSTALL_DATADIR}/${PROJECT_NAME}"
+    CACHE STRING "cpmm data directory" FORCE)
+# Installation directory for cppmm resources (share/cppmm/resources)
+set(CPPMM_PACKAGE_RESOURCES_DIR "${CMAKE_INSTALL_PACKAGE_DATADIR}/resources"
+    CACHE STRING "cpmm resources directory" FORCE)
+
+
 # LLVM is normally built without RTTI. Be consistent with that.
 if(NOT LLVM_ENABLE_RTTI)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")

--- a/astgen/CMakeLists.txt
+++ b/astgen/CMakeLists.txt
@@ -12,5 +12,4 @@ target_include_directories(astgen PRIVATE ${LLVM_INCLUDE_DIRS})
 file(COPY resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 # Install the headers alongside the binary
 install(DIRECTORY resources DESTINATION ${CMAKE_INSTALL_PREFIX})
-
-
+install(TARGETS astgen DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/astgen/CMakeLists.txt
+++ b/astgen/CMakeLists.txt
@@ -6,10 +6,13 @@ add_executable(astgen
 
 target_link_libraries(astgen clangTooling clangBasic clangASTMatchers spdlog::spdlog nlohmann_json::nlohmann_json)
 target_compile_definitions(astgen PRIVATE SPDLOG_ACTIVE_LEVEL=TRACE)
+target_compile_definitions(astgen PRIVATE
+    CPPMM_PACKAGE_RESOURCES_DIR="${CPPMM_PACKAGE_RESOURCES_DIR}")
 target_include_directories(astgen PRIVATE ${LLVM_INCLUDE_DIRS})
 
 # Copy the clang headers to the build directory so tests work
-file(COPY resources DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+file(COPY resources/ DESTINATION
+    "${CMAKE_CURRENT_BINARY_DIR}/../${CPPMM_PACKAGE_RESOURCES_DIR}")
 # Install the headers alongside the binary
-install(DIRECTORY resources DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(DIRECTORY resources/ DESTINATION ${CPPMM_PACKAGE_RESOURCES_DIR})
 install(TARGETS astgen DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/astgen/src/astgen.cpp
+++ b/astgen/src/astgen.cpp
@@ -21,6 +21,10 @@
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
 
+#ifndef CPPMM_PACKAGE_RESOURCES_DIR
+#error "CPPMM_PACKAGE_RESOURCES_DIR is undefined and must be provided"
+#endif
+
 using namespace clang::tooling;
 using namespace llvm;
 using namespace clang;
@@ -123,7 +127,8 @@ int main(int argc_, const char** argv_) {
         return -1;
     }
 
-    std::string respath1 = (exe_path.parent_path() / "resources").string();
+    std::string respath1 =
+        (exe_path.parent_path() / CPPMM_PACKAGE_RESOURCES_DIR).string();
     if (!has_ddash) {
         argv[i++] = "--";
         argc++;

--- a/asttoc/CMakeLists.txt
+++ b/asttoc/CMakeLists.txt
@@ -16,3 +16,4 @@ target_include_directories(asttoc PRIVATE fmt/include)
 target_include_directories(asttoc PRIVATE ${LLVM_INCLUDE_DIRS})
 
 target_link_libraries(asttoc fmt LLVMSupport)
+install(TARGETS asttoc DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
Update the build system to install `astgen` and `asttoc`.

Adjust the installation paths to use conventional locations from the FIlesystem Hierarchy Standard.