### PR TITLE
test/std/bind: add a constructor to basic_string

### DIFF
--- a/test/std/bind/std_string.cpp
+++ b/test/std/bind/std_string.cpp
@@ -10,6 +10,8 @@ class basic_string {
 public:
     using BoundType = ::std::string;
 
+    basic_string() = default;
+
     // We can't match against the constructor without specifying an allocator
     // parameter, but we definitely don't want to be passing that from C so
     // we could use CPPMM_IGNORE here to indicate that we allow this parameter


### PR DESCRIPTION
XCode 12 and possibly other versions fail to generate bindings
with the reference std_string.cpp binding unless a default
constructor is provided.

    $ gcc -v
    Configured with:
    --prefix=/Applications/Xcode.app/Contents/Developer/usr
    --with-gxx-include-dir=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/4.2.1
    Apple clang version 12.0.0 (clang-1200.0.32.29)
    Target: x86_64-apple-darwin19.6.0
    Thread model: posix

The following astgen errors are produced without this change:

    test/std/bind/std_string.cpp:23:3: error:
     no matching constructor for initialization of 'class basic_string'
        } CPPMM_OPAQUEBYTES;
        ^
    test/std/bind/std_string.cpp:9:7: note:
      candidate constructor (the implicit copy constructor) not viable:
      requires 1 argument, but 0 were provided
        class basic_string {
              ^
    test/std/bind/std_string.cpp:9:7: note:
      candidate constructor (the implicit move constructor) not viable:
      requires 1 argument, but 0 were provided
    test/std/bind/std_string.cpp:18:5: note:
      candidate constructor not viable:
      requires 3 arguments, but 0 were provided
        basic_string(const char* s, ::std::string::size_type count,
        ^

Related-to: #52