### PR TITLE
std::string in openexr [Not ready for merge]

### DIFF
--- a/bind.sh
+++ b/bind.sh
@@ -3,16 +3,16 @@ project=openexr
 pushd build
 
 # Generate the ast
-#./astgen/astgen ../test/$project/bind -u              \
-#    -o ../test/$project/ref/ast                   \
-#    -rust-sys $PWD/../test/std/rust      \
-#    --                                   \
-#    -I/Volumes/src/cppmm/test/                   \
-#    -I/Volumes/src/packages/include \
-#    -I/Volumes/src/packages/include/OpenEXR \
-#    -I/usr/local/include \
-#    -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk \
-#    -isystem /Volumes/src/clang+llvm-11.0.0-x86_64-apple-darwin/include/c++/v1
+./astgen/astgen ../test/$project/bind -u              \
+    -o ../test/$project/ref/ast                   \
+    -rust-sys $PWD/../test/std/rust      \
+    --                                   \
+    -I/Volumes/src/cppmm/test/                   \
+    -I/Volumes/src/packages/include \
+    -I/Volumes/src/packages/include/OpenEXR \
+    -I/usr/local/include \
+    -isysroot/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk \
+    -isystem /Volumes/src/clang+llvm-11.0.0-x86_64-apple-darwin/include/c++/v1
 ##
 ##-i $PWD/../test/$project/bind             \
 #-I/Volumes/src/cppmm/test/$project/bind                   \

--- a/test/openexr/bind/std_string.cpp
+++ b/test/openexr/bind/std_string.cpp
@@ -1,0 +1,25 @@
+#include <string>
+
+#include <cppmm_bind.hpp>
+
+namespace cppmm_bind {
+
+namespace std {
+
+class basic_string {
+public:
+    using BoundType = ::std::string;
+
+    basic_string();
+    basic_string(const ::std::string & rhs);
+
+    ::std::string& assign(const char* s, ::std::string::size_type count);
+    const char* c_str() const;
+
+} CPPMM_OPAQUEBYTES;
+
+using string = ::std::string;
+
+} // namespace std
+
+} // namespace cppmm_bind

--- a/test/openexr/bind/std_vector.cpp
+++ b/test/openexr/bind/std_vector.cpp
@@ -1,0 +1,30 @@
+#include <vector>
+#include <string>
+
+// CPPMM_ macro definitions etc automatically inserted in this virtual header
+#include <cppmm_bind.hpp>
+
+namespace cppmm_bind {
+
+namespace std {
+
+template <class T> class vector {
+public:
+    // This allows us to see through to the type in Imath
+    using BoundType = ::std::vector<T>;
+
+    vector();
+    ~vector();
+
+} CPPMM_OPAQUEBYTES;
+
+// explicit instantiation
+template class vector<::std::string>;
+
+using vector_string = ::std::vector<::std::string>;
+
+} // namespace std
+
+} // namespace cppmm_bind
+
+template class std::vector<std::string>;


### PR DESCRIPTION
Copied across and updated std_string.cpp bind file into openexr folder. This brings online the methods that take std::string as a parameter and that return it as a value.