### PR TITLE
63 name mangling

### DIFF
--- a/asttoc/include/cppmm_ast.hpp
+++ b/asttoc/include/cppmm_ast.hpp
@@ -123,9 +123,12 @@ struct TranslationUnit {
 //------------------------------------------------------------------------------
 struct NodeNamespace : public Node {
     std::string short_name;
+    std::string alias;
 
-    NodeNamespace(std::string name, NodeId id, std::string short_name)
-        : Node(name, id, NodeKind::Namespace), short_name(short_name) {}
+    NodeNamespace(std::string name, NodeId id, std::string short_name,
+                  std::string alias)
+        : Node(name, id, NodeKind::Namespace), short_name(short_name),
+          alias(alias) {}
 
     // A static method for creating this as a shared pointer
     using This = NodeNamespace;
@@ -525,6 +528,7 @@ struct NodePlacementNewExpr
 //------------------------------------------------------------------------------
 struct NodeFunction : public NodeAttributeHolder {
     std::string short_name;
+    std::string nice_name;
     NodeTypePtr return_type;
     std::vector<Param> params;
     bool in_binding = false;
@@ -536,10 +540,11 @@ struct NodeFunction : public NodeAttributeHolder {
 
     NodeFunction(std::string qualified_name, NodeId id,
                  std::vector<std::string> attrs, std::string short_name,
-                 NodeTypePtr&& return_type, std::vector<Param>&& params)
+                 NodeTypePtr&& return_type, std::vector<Param>&& params,
+                 std::string nice_name)
         : NodeAttributeHolder(qualified_name, id, NodeKind::Function, attrs),
           short_name(short_name), return_type(std::move(return_type)),
-          params(std::move(params)) {}
+          params(std::move(params)), nice_name(std::move(nice_name)) {}
 
     // A static method for creating this as a shared pointer
     using This = NodeFunction;
@@ -564,7 +569,8 @@ struct NodeMethod : public NodeFunction {
                bool is_static, bool is_constructor, bool is_copy_constructor,
                bool is_destructor, bool is_const)
         : NodeFunction(qualified_name, id, attrs, short_name,
-                       std::move(return_type), std::move(params)),
+                       std::move(return_type), std::move(params),
+                       qualified_name),
           is_static(is_static), is_constructor(is_constructor),
           is_copy_constructor(is_copy_constructor),
           is_destructor(is_destructor), is_const(is_const) {
@@ -603,6 +609,8 @@ struct NodeRecord : public NodeAttributeHolder {
 
     bool abstract;
     bool trivially_copyable;
+
+    std::string nice_name;
 
     NodeRecord(const TranslationUnit::Ptr& tu, std::string qualified_name,
                NodeId id, std::vector<std::string> attrs, uint32_t size,

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -182,7 +182,8 @@ NodePtr read_function(const TranslationUnit::Ptr& tu, const nln::json& json) {
     }
 
     auto result = NodeFunction::n(qualified_name, id, _attrs, short_name,
-                                  std::move(return_type), std::move(params));
+                                  std::move(return_type), std::move(params),
+                                  qualified_name);
     result->namespaces = namespaces;
 
     return result;
@@ -349,8 +350,9 @@ NodePtr read_namespace(const TranslationUnit::Ptr& tu, const nln::json& json) {
     Id id = json[ID].get<Id>();
     auto name = json[NAME].get<std::string>();
     auto short_name = json[SHORT_NAME].get<std::string>();
+    auto alias = json[ALIAS].get<std::string>();
 
-    auto result = NodeNamespace::n(name, id, short_name);
+    auto result = NodeNamespace::n(name, id, short_name, alias);
 
     // Return the result
     return result;

--- a/asttoc/src/cppmm_ast_write_c.cpp
+++ b/asttoc/src/cppmm_ast_write_c.cpp
@@ -128,6 +128,7 @@ void write_record(fmt::ostream& out, const NodePtr& node) {
               align_in_bytes, // TODO LT: Only force alignment if 'align'
                               // attribute is on it.
               record.name);
+    out.print("typedef {} {};\n\n", record.name, record.nice_name);
 }
 
 //------------------------------------------------------------------------------
@@ -182,6 +183,19 @@ void write_function_dcl(fmt::ostream& out, const NodePtr& node, Access access) {
         out.print("{}(", convert_param(function.return_type, function.name));
         write_params(out, function);
         out.print(");\n");
+    }
+}
+
+//------------------------------------------------------------------------------
+void write_function_define(fmt::ostream& out, const NodePtr& node,
+                           Access access) {
+    const NodeFunction& function =
+        *static_cast<const NodeFunction*>(node.get());
+
+    const bool private_ = (access == Access::Private);
+    if (private_ == function.private_) {
+        out.print("\n");
+        out.print("#define {} {}\n\n", function.nice_name, function.name);
     }
 }
 
@@ -395,6 +409,7 @@ void write_function(fmt::ostream& out, const NodePtr& node, Access access,
         switch (place) {
         case Place::Header:
             write_function_bdy(out, node, access);
+            write_function_define(out, node, access);
             return;
         default:
             return;
@@ -403,6 +418,7 @@ void write_function(fmt::ostream& out, const NodePtr& node, Access access,
         switch (place) {
         case Place::Header:
             write_function_dcl(out, node, access);
+            write_function_define(out, node, access);
             return;
         case Place::Source:
             write_function_bdy(out, node, access);


### PR DESCRIPTION
This adds the mangling approach discussed in https://github.com/vfx-rs/cppmm/issues/63 by using the simple Maya-style name mangling and adding defines and typedefs for "nice" names that are not versioned so client code can recompile against new versions without changes.