### PR TITLE
Prune stl version namespace from astgen output

### DIFF
--- a/astgen/src/ast.cpp
+++ b/astgen/src/ast.cpp
@@ -84,6 +84,10 @@ std::unordered_map<std::string, std::pair<std::string, bool>> NAMESPACE_ALIASES;
 /// Function prototype typedefs
 std::unordered_map<std::string, std::string> FPT_TYPEDEFS;
 
+static bool is_stl_version_namespace(const std::string & name) {
+    return name == "std::__1";
+}
+
 void Node::write_json_attrs(json& o) const {
     if (id >= 0) {
         o["id"] = id;
@@ -102,9 +106,12 @@ void NodeTranslationUnit::write_json(json& o) const {
     o["decls"] = {};
     for (NodeId id : children) {
         const Node* node = NODES.at(id).get();
-        auto child = json::object();
-        node->write_json(child);
-        o["decls"].emplace_back(std::move(child));
+        if(!is_stl_version_namespace(node->qualified_name))
+        {
+            auto child = json::object();
+            node->write_json(child);
+            o["decls"].emplace_back(std::move(child));
+        }
     }
 }
 

--- a/astgen/src/ast.cpp
+++ b/astgen/src/ast.cpp
@@ -14,6 +14,10 @@ namespace fs = ghc::filesystem;
 
 namespace cppmm {
 
+static std::string prune_stl(const std::string & str) {
+    return pystring::replace(str, "std::__1", "std");
+}
+
 std::ostream& operator<<(std::ostream& os, NodeKind k) {
     switch (k) {
     case NodeKind::Node:
@@ -117,7 +121,7 @@ void NodeNamespace::write_json_attrs(json& o) const {
 
 void NodeNamespace::write_json(json& o) const {
     o["kind"] = "Namespace";
-    o["name"] = qualified_name;
+    o["name"] = prune_stl(qualified_name);
     write_json_attrs(o);
 }
 
@@ -235,7 +239,7 @@ void NodeVar::write_json_attrs(json& o) const {
 
 void NodeVar::write_json(json& o) const {
     o["kind"] = "Var";
-    o["qualified_name"] = qualified_name;
+    o["qualified_name"] = prune_stl(qualified_name);
     o["short_name"] = short_name;
     o["type"] = {};
     qtype.write_json(o["type"]);
@@ -252,7 +256,7 @@ void Exception::write_json(json& o) const {
 void NodeFunction::write_json_attrs(json& o) const {
     NodeAttributeHolder::write_json_attrs(o);
     o["short_name"] = short_name;
-    o["qualified_name"] = qualified_name;
+    o["qualified_name"] = prune_stl(qualified_name);
     o["in_binding"] = in_binding;
     o["in_library"] = in_library;
     o["noexcept"] = is_noexcept;
@@ -406,7 +410,7 @@ void NodeRecord::write_json_attrs(json& o) const {
 
 void NodeRecord::write_json(json& o) const {
     o["kind"] = "Record";
-    o["name"] = qualified_name;
+    o["name"] = prune_stl(qualified_name);
     o["short_name"] = short_name;
     o["namespaces"] = namespaces;
     write_json_attrs(o);
@@ -438,7 +442,7 @@ void NodeEnum::write_json_attrs(json& o) const {
 
 void NodeEnum::write_json(json& o) const {
     o["kind"] = "Enum";
-    o["name"] = qualified_name;
+    o["name"] = prune_stl(qualified_name);
     o["short_name"] = short_name;
     o["namespaces"] = namespaces;
     write_json_attrs(o);
@@ -456,7 +460,7 @@ void NodeFunctionPointerTypedef::write_json_attrs(json& o) const {
 
 void NodeFunctionPointerTypedef::write_json(json& o) const {
     o["kind"] = "FunctionPointerTypedef";
-    o["name"] = qualified_name;
+    o["name"] = prune_stl(qualified_name);
     o["alias"] = alias;
     o["namespaces"] = namespaces;
 

--- a/astgen/src/ast.cpp
+++ b/astgen/src/ast.cpp
@@ -1,5 +1,7 @@
 #include "ast.hpp"
 
+#include "stl_prune.hpp"
+
 #include <iomanip>
 
 #define SPDLOG_ACTIVE_LEVEL TRACE
@@ -13,10 +15,6 @@ namespace fs = ghc::filesystem;
 #include "pystring.h"
 
 namespace cppmm {
-
-static std::string prune_stl(const std::string & str) {
-    return pystring::replace(str, "std::__1", "std");
-}
 
 std::ostream& operator<<(std::ostream& os, NodeKind k) {
     switch (k) {
@@ -84,10 +82,6 @@ std::unordered_map<std::string, std::pair<std::string, bool>> NAMESPACE_ALIASES;
 /// Function prototype typedefs
 std::unordered_map<std::string, std::string> FPT_TYPEDEFS;
 
-static bool is_stl_version_namespace(const std::string & name) {
-    return name == "std::__1";
-}
-
 void Node::write_json_attrs(json& o) const {
     if (id >= 0) {
         o["id"] = id;
@@ -106,8 +100,7 @@ void NodeTranslationUnit::write_json(json& o) const {
     o["decls"] = {};
     for (NodeId id : children) {
         const Node* node = NODES.at(id).get();
-        if(!is_stl_version_namespace(node->qualified_name))
-        {
+        if (!is_stl_version_namespace(node->qualified_name)) {
             auto child = json::object();
             node->write_json(child);
             o["decls"].emplace_back(std::move(child));

--- a/astgen/src/process_binding.cpp
+++ b/astgen/src/process_binding.cpp
@@ -66,6 +66,10 @@ bool get_abi_info(const TypeDecl* td, ASTContext& ctx, uint32_t& size,
     return false;
 }
 
+bool is_stl_version_namespace(const std::string & name) {
+    return name == "std::__1";
+}
+
 QType process_qtype(const QualType& qt);
 
 /// Create a new NodeFunctionProtoType from the given FunctionProtoType and
@@ -651,6 +655,7 @@ std::vector<NodeId> get_namespaces(const clang::DeclContext* parent,
                 static_cast<const clang::NamespaceDecl*>(parent);
 
             auto qualified_name = ns->getQualifiedNameAsString();
+
             auto short_name = ns->getNameAsString();
             if (short_name == "cppmm_bind") {
                 break;
@@ -691,7 +696,10 @@ std::vector<NodeId> get_namespaces(const clang::DeclContext* parent,
                              node_tu->qualified_name);
                 node_tu->children.push_back(id);
             }
-            result.push_back(id);
+
+            if(!is_stl_version_namespace(qualified_name)) {
+                result.push_back(id);
+            }
 
             parent = parent->getParent();
         } else if (parent->isRecord()) {

--- a/astgen/src/process_binding.cpp
+++ b/astgen/src/process_binding.cpp
@@ -28,6 +28,7 @@ namespace fs = ghc::filesystem;
 
 #include "ast.hpp"
 #include "ast_utils.hpp"
+#include "stl_prune.hpp"
 
 using namespace clang;
 using namespace clang::ast_matchers;
@@ -64,10 +65,6 @@ bool get_abi_info(const TypeDecl* td, ASTContext& ctx, uint32_t& size,
     }
 
     return false;
-}
-
-bool is_stl_version_namespace(const std::string & name) {
-    return name == "std::__1";
 }
 
 QType process_qtype(const QualType& qt);
@@ -697,7 +694,7 @@ std::vector<NodeId> get_namespaces(const clang::DeclContext* parent,
                 node_tu->children.push_back(id);
             }
 
-            if(!is_stl_version_namespace(qualified_name)) {
+            if (!is_stl_version_namespace(qualified_name)) {
                 result.push_back(id);
             }
 

--- a/astgen/src/stl_prune.hpp
+++ b/astgen/src/stl_prune.hpp
@@ -4,11 +4,12 @@
 namespace cppmm {
 
 inline bool is_stl_version_namespace(const std::string& name) {
-    return name == "std::__1";
+    return (name == "std::__1") || (name == "std::__cxx11");
 }
 
 inline std::string prune_stl(const std::string& str) {
-    return pystring::replace(str, "std::__1", "std");
+    return pystring::replace(pystring::replace(str, "std::__1", "std"),
+                             "std::__cxx11", "std");
 }
 
 } // namespace cppmm

--- a/astgen/src/stl_prune.hpp
+++ b/astgen/src/stl_prune.hpp
@@ -1,0 +1,14 @@
+#pragma once
+#include "pystring.h"
+
+namespace cppmm {
+
+inline bool is_stl_version_namespace(const std::string& name) {
+    return name == "std::__1";
+}
+
+inline std::string prune_stl(const std::string& str) {
+    return pystring::replace(str, "std::__1", "std");
+}
+
+} // namespace cppmm


### PR DESCRIPTION
The benefit to pruning on the astgen side is that it takes us one step closer to making the ast json files portable. In the future we might produce the json as an artifact that other developers can use to easily produce bindings for other languages.
