### PR TITLE
Stl symbol explicit naming

### DIFF
--- a/astgen/src/astgen.cpp
+++ b/astgen/src/astgen.cpp
@@ -206,6 +206,7 @@ int main(int argc_, const char** argv_) {
 
 #define CPPMM_THROWS(EX, VAR) __attribute__((annotate("cppmm|throws|" #EX "|" #VAR)))
 #define CPPMM_NOEXCEPT __attribute__((annotate("cppmm|noexcept")))
+#define CPPMM_FORCE_NAME(x) __attribute__((annotate("cppmm|force_name|" #x)))
 
 #define CPPMM_ENUM_PREFIX(x) __attribute__((annotate("cppmm|enum_prefix|" #x)))
 #define CPPMM_ENUM_SUFFIX(x) __attribute__((annotate("cppmm|enum_suffix|" #x)))

--- a/astgen/src/process_binding.cpp
+++ b/astgen/src/process_binding.cpp
@@ -906,6 +906,8 @@ void handle_typealias_decl(const TypeAliasDecl* tad, const CXXRecordDecl* crd) {
         return;
     }
 
+    auto attrs = get_attrs(tad);
+
     // First of all, make sure we have already processed the Record that this
     // alias refers to. I *think* this should always have happened, but not sure
     // yet
@@ -914,10 +916,17 @@ void handle_typealias_decl(const TypeAliasDecl* tad, const CXXRecordDecl* crd) {
         SPDLOG_DEBUG("Storing alias {} for {}", alias_name,
                      record_qualified_name);
         pending_aliases[mangled_name] = alias_name;
+
+        // TODO LT: Add pending_attrs
     } else {
         NodeId id_rec = it->second;
         NodeRecord* node_rec = (NodeRecord*)NODES[id_rec].get();
         node_rec->alias = alias_name;
+
+        // Add the typedef attributes to the node record.
+        for(auto i: attrs) {
+            node_rec->attrs.push_back(i);
+        }
     }
 }
 

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -6,6 +6,7 @@
 #include "base64.hpp"
 #include "filesystem.hpp"
 #include "json.hh"
+#include "pystring.h"
 
 #include <iostream>
 #include <memory>
@@ -377,6 +378,15 @@ NodePtr read_record(const TranslationUnit::Ptr& tu, const nln::json& json) {
 
     // Pull out the attributes
     std::vector<std::string> attrs = read_attrs(json);
+
+    // Force override the qualified name of the record on file read
+    for(auto a: attrs){
+        static const char FORCE_NAME[] = "cppmm|force_name|";
+        if(pystring::startswith(a, FORCE_NAME)){
+            const auto fn_len = sizeof(FORCE_NAME);
+            qual_name = pystring::slice(a, fn_len, -2);
+        }
+    }
 
     // Read the comment
     auto comment = read_comment(json);

--- a/asttoc/src/cppmm_ast_read.cpp
+++ b/asttoc/src/cppmm_ast_read.cpp
@@ -384,7 +384,7 @@ NodePtr read_record(const TranslationUnit::Ptr& tu, const nln::json& json) {
         static const char FORCE_NAME[] = "cppmm|force_name|";
         if(pystring::startswith(a, FORCE_NAME)){
             const auto fn_len = sizeof(FORCE_NAME);
-            qual_name = pystring::slice(a, fn_len, -2);
+            qual_name = pystring::slice(a, fn_len, -1);
         }
     }
 


### PR DESCRIPTION
This makes it possible to force override the qualified name of a record. This makes it possible to wrap stl in a portable way.