### PR TITLE
Adjust cppmm bindings for building on docs.rs

### DIFF
--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -660,6 +660,10 @@ regex = "^1.5"
 quick-xml = "0.22"
 
 [dependencies]
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
 )",
                     project_name, version_major, version_minor, version_patch);
 

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -669,6 +669,11 @@ quick-xml = "0.22"
     auto build_rs = fmt::output_file((fs::path(out_dir) / "build.rs").string());
     build_rs.print(R"#(
 fn main() {{
+    // Skip linking on docs.rs: https://docs.rs/about/builds#detecting-docsrs
+    let building_docs = std::env::var("DOCS_RS").is_ok();
+    if building_docs {{
+        return;
+    }}
     let dst = cmake::Config::new("{0}").build();
     println!("cargo:rustc-link-search=native={{}}", dst.display());
     println!("cargo:rustc-link-lib=dylib={1}-c-{2}_{3}");


### PR DESCRIPTION
In theory this should make it possible for docs.rs to build docs for wrapped projects.

I haven't tested this yet but will do so in the next ptex update.