### PR TITLE
docs.rs, licensing and author metadata

### DIFF
--- a/asttoc/include/cppmm_ast_write_rustsys.hpp
+++ b/asttoc/include/cppmm_ast_write_rustsys.hpp
@@ -11,7 +11,8 @@ namespace cppmm {
 class Root;
 
 namespace rust_sys {
-void write(const char* out_dir, const char* project_name, const char* c_dir,
+void write(const char* out_dir, const char* project_name,
+           const char* c_dir, const std::string& c_cmake_dir,
            const Root& root, size_t starting_point,
            const std::vector<std::string>& libs,
            const std::vector<std::string>& lib_dirs, int version_major,

--- a/asttoc/include/cppmm_ast_write_rustsys.hpp
+++ b/asttoc/include/cppmm_ast_write_rustsys.hpp
@@ -11,7 +11,7 @@ namespace cppmm {
 class Root;
 
 namespace rust_sys {
-void write(const char* out_dir, const char* project_name,
+void write(const char* out_dir, const char* project_name, const char* license,
            const char* c_dir, const std::string& c_cmake_dir,
            const Root& root, size_t starting_point,
            const std::vector<std::string>& libs,

--- a/asttoc/include/cppmm_ast_write_rustsys.hpp
+++ b/asttoc/include/cppmm_ast_write_rustsys.hpp
@@ -15,7 +15,8 @@ void write(const char* out_dir, const char* project_name,
            const char* c_dir, const std::string& c_cmake_dir,
            const Root& root, size_t starting_point,
            const std::vector<std::string>& libs,
-           const std::vector<std::string>& lib_dirs, int version_major,
-           int version_minor, int version_patch);
+           const std::vector<std::string>& lib_dirs,
+           const std::vector<std::string>& authors,
+           int version_major, int version_minor, int version_patch);
 } // namespace rust_sys
 } // namespace cppmm

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -562,19 +562,22 @@ impl std::error::Error for Error {{
 }}
 
 use std::fmt;
-impl fmt::Display for Error {{
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {{
-)");
+
+impl fmt::Display for Error {{)");
 
     if (EXCEPTION_MAP.empty()) {
         out_lib.print(R"(
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {{
         Ok(())
     }}
 }}
+
 )");
+
     } else {
 
         out_lib.print(R"(
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {{
         match self {{
     )");
 
@@ -588,6 +591,7 @@ impl fmt::Display for Error {{
         }}
     }}
 }}
+
 )");
     }
 

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -487,7 +487,7 @@ void write_modules(fs::path dir) {
     }
 }
 
-void write(const char* out_dir, const char* project_name,
+void write(const char* out_dir, const char* project_name, const char* license,
            const char* c_dir, const std::string& c_cmake_dir,
            const Root& root, size_t starting_point,
            const std::vector<std::string>& libs,
@@ -675,9 +675,11 @@ mod test;
         fmt::format(R"(
 [package]
 name = "{}-sys"
+description = "cppmm sys bindings for {}"
 version = "{}.{}.{}"
 authors = [{}]
 edition = "2021"
+license = "{}"
 
 [build-dependencies]
 cmake = "0.1"
@@ -691,8 +693,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 rustc-args = ["--cfg", "docsrs"]
 
 )",
-                    project_name, version_major, version_minor, version_patch,
-                    authors_list_str);
+                    project_name, project_name,
+                    version_major, version_minor, version_patch,
+                    authors_list_str, license);
 
     auto out_cargo_toml = fmt::output_file(p_cargo_toml.string());
     out_cargo_toml.print(cargo_toml);

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -487,7 +487,8 @@ void write_modules(fs::path dir) {
     }
 }
 
-void write(const char* out_dir, const char* project_name, const char* c_dir,
+void write(const char* out_dir, const char* project_name,
+           const char* c_dir, const std::string& c_cmake_dir,
            const Root& root, size_t starting_point,
            const std::vector<std::string>& libs,
            const std::vector<std::string>& lib_dirs, int version_major,
@@ -699,7 +700,7 @@ fn main() {{
 
 
 )#",
-                   c_dir, project_name, version_major, version_minor);
+                   c_cmake_dir.c_str(), project_name, version_major, version_minor);
 
     for (const auto& d : lib_dirs) {
         build_rs.print("    println!(\"cargo:rustc-link-search=native={}\");\n",

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -491,7 +491,9 @@ void write(const char* out_dir, const char* project_name,
            const char* c_dir, const std::string& c_cmake_dir,
            const Root& root, size_t starting_point,
            const std::vector<std::string>& libs,
-           const std::vector<std::string>& lib_dirs, int version_major,
+           const std::vector<std::string>& lib_dirs,
+           const std::vector<std::string>& authors,
+           int version_major,
            int version_minor, int version_patch) {
 
     expect(starting_point < root.tus.size(),
@@ -647,12 +649,23 @@ fn it_works() {{
 mod test;
 )#");
 
+    // Generate the quoted interior of the "authors = [...]" string list.
+    std::string authors_list_str;
+    for (const auto& author : authors) {
+        if (!authors_list_str.empty()) {
+            authors_list_str += ", ";
+        }
+        authors_list_str += '"';
+        authors_list_str += author;
+        authors_list_str += '"';
+    }
+
     std::string cargo_toml =
         fmt::format(R"(
 [package]
 name = "{}-sys"
 version = "{}.{}.{}"
-authors = ["Anders Langlands <anderslanglands@gmail.com>"]
+authors = [{}]
 edition = "2018"
 
 [build-dependencies]
@@ -666,7 +679,8 @@ quick-xml = "0.22"
 targets = ["x86_64-unknown-linux-gnu"]
 
 )",
-                    project_name, version_major, version_minor, version_patch);
+                    project_name, version_major, version_minor, version_patch,
+                    authors_list_str);
 
     auto out_cargo_toml = fmt::output_file(p_cargo_toml.string());
     out_cargo_toml.print(cargo_toml);

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -666,7 +666,7 @@ mod test;
 name = "{}-sys"
 version = "{}.{}.{}"
 authors = [{}]
-edition = "2018"
+edition = "2021"
 
 [build-dependencies]
 cmake = "0.1"

--- a/asttoc/src/cppmm_ast_write_rustsys.cpp
+++ b/asttoc/src/cppmm_ast_write_rustsys.cpp
@@ -736,7 +736,7 @@ fn main() {{
             "cppmm_abi_in", 
             &format!("{{}}/cppmm_abi_out", out_dir), 
             &format!("{{}}/build/abigen.txt", out_dir)])
-        .output().expect("couldn't do the thing");
+        .output().expect("insert_abi.py failed to generate cppmm_abi_out");
 
     if !output.status.success() {{
         for line in std::str::from_utf8(&output.stderr).unwrap().lines() {{

--- a/asttoc/src/main.cpp
+++ b/asttoc/src/main.cpp
@@ -38,6 +38,11 @@ static cl::opt<std::string> opt_project_name(
     "p", cl::desc("Name for the project. This will determine the name of the "
                   "generated C library and the rust crate"));
 
+static cl::opt<std::string> opt_license(
+    "license",
+    cl::desc("License for the project. This will be written into the "
+             "generated Cargo.toml for the sys rust crate"));
+
 static cl::opt<std::string> opt_c_cmake_dir(
     "cmake",
     cl::desc("Relative  path to lib-sys/lib-c to write into build.rs. "
@@ -83,7 +88,7 @@ template <typename T> std::vector<std::string> to_vector(const T& t) {
     return result;
 }
 
-void generate(const char* input, const char* project_name,
+void generate(const char* input, const char* project_name, const char* license,
               const char* output, const std::string& c_cmake_dir,
               const char* rust_output, const cppmm::Libs& libs,
               const cppmm::LibDirs& lib_dirs,
@@ -140,7 +145,8 @@ void generate(const char* input, const char* project_name,
     std::string cwd = fs::current_path().string();
     std::string c_dir = pystring::os::path::abspath(output_directory, cwd);
 
-    cppmm::rust_sys::write(rust_output, project_name, c_dir.c_str(), c_cmake_dir,
+    cppmm::rust_sys::write(rust_output, project_name, license,
+                           c_dir.c_str(), c_cmake_dir,
                            cpp_ast, starting_point, libs, lib_dirs,
                            authors, version_major, version_minor, version_patch);
 }
@@ -194,6 +200,12 @@ int main(int argc, char** argv) {
         return -3;
     }
 
+    // license is optional and defaults to "MIT".
+    std::string license("MIT");
+    if (!opt_license.empty()) {
+        license = opt_license;
+    }
+
     std::string c_cmake_dir;
     if (!opt_c_cmake_dir.empty()) {
         c_cmake_dir = opt_c_cmake_dir;
@@ -236,7 +248,8 @@ int main(int argc, char** argv) {
         authors.emplace_back(std::string("Anders Langlands <anderslanglands@gmail.com>"));
     }
 
-    generate(opt_in_dir.c_str(), project_name.c_str(), c_dir.c_str(), c_cmake_dir,
+    generate(opt_in_dir.c_str(), project_name.c_str(), license.c_str(),
+             c_dir.c_str(), c_cmake_dir,
              rust_dir.c_str(), libs, lib_dirs, find_packages, target_link_libraries,
              authors, opt_version_major, opt_version_minor, opt_version_patch);
 

--- a/asttoc/src/main.cpp
+++ b/asttoc/src/main.cpp
@@ -44,6 +44,9 @@ static cl::opt<std::string> opt_c_cmake_dir(
              "Defaults to <out-dir>/<lib>-sys/<lib>-c."));
 
 static cl::list<std::string>
+    opt_author("author", cl::desc("Specify authors for Cargo.toml."), cl::ZeroOrMore);
+
+static cl::list<std::string>
     opt_lib("l", cl::desc("Library that bindings link to."), cl::ZeroOrMore);
 
 static cl::list<std::string>
@@ -86,6 +89,7 @@ void generate(const char* input, const char* project_name,
               const cppmm::LibDirs& lib_dirs,
               const std::vector<std::string>& find_packages,
               const std::vector<std::string>& target_link_libraries,
+              const std::vector<std::string>& authors,
               int version_major, int version_minor, int version_patch) {
     const std::string input_directory = input;
     const std::string output_directory = output;
@@ -137,8 +141,8 @@ void generate(const char* input, const char* project_name,
     std::string c_dir = pystring::os::path::abspath(output_directory, cwd);
 
     cppmm::rust_sys::write(rust_output, project_name, c_dir.c_str(), c_cmake_dir,
-                           cpp_ast, starting_point, libs, lib_dirs, version_major,
-                           version_minor, version_patch);
+                           cpp_ast, starting_point, libs, lib_dirs,
+                           authors, version_major, version_minor, version_patch);
 }
 
 int main(int argc, char** argv) {
@@ -226,10 +230,15 @@ int main(int argc, char** argv) {
     auto lib_dirs = to_vector(opt_lib_dir);
     auto find_packages = to_vector(opt_find_package);
     auto target_link_libraries = to_vector(opt_target_link_libraries);
+
+    std::vector<std::string> authors = to_vector(opt_author);
+    if (authors.empty()) {
+        authors.emplace_back(std::string("Anders Langlands <anderslanglands@gmail.com>"));
+    }
+
     generate(opt_in_dir.c_str(), project_name.c_str(), c_dir.c_str(), c_cmake_dir,
-             rust_dir.c_str(), libs, lib_dirs, find_packages,
-             target_link_libraries, opt_version_major, opt_version_minor,
-             opt_version_patch);
+             rust_dir.c_str(), libs, lib_dirs, find_packages, target_link_libraries,
+             authors, opt_version_major, opt_version_minor, opt_version_patch);
 
     return 0;
 }


### PR DESCRIPTION
Revamp cppmm so that it we can generate documention using docs.rs.

Examples

- sys bindings: https://docs.rs/ptex-sys/0.0.6/ptex_sys/

- high-level bindings: https://docs.rs/ptex/0.0.6/ptex/

The basic gist of it is that we provide a canned cppmmabi_generated.rs that gets used by docs.rs only. We use the `--cfg docsrs` configuration to handle it.

I also made it so that the "author" and "license" fields in the Cargo.toml can be specified when invoking asttoc. This made it so that we can use the generated bindings and upload them as-is to crates.io.

These features are being relied upon by ptex's bind.sh. I'd be happy to walk someone through the process.

There is docs.rs metadata that I had to add to both the generated sys Cargo.toml (part of this change) and the hand-written ptex-rs Cargo.toml to make it all work.